### PR TITLE
Parametrize tests for transformation functions

### DIFF
--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -13,6 +13,7 @@ screen_cm_1d = 100
 screen_px_2d = [100, 100]
 screen_cm_2d = [100, 100]
 
+
 @pytest.mark.parametrize(
     'kwargs, expected_error',
     [
@@ -24,7 +25,7 @@ screen_cm_2d = [100, 100]
                 'distance_cm': 1
             },
             TypeError,
-            id='none_coords_raise_type_error'
+            id='none_coords_raises_type_error'
         ),
         pytest.param(
             {
@@ -34,7 +35,7 @@ screen_cm_2d = [100, 100]
                 'distance_cm': 1
             },
             TypeError,
-            id='none_screen_px_raise_type_error'
+            id='none_screen_px_raises_type_error'
         ),
         pytest.param(
             {
@@ -44,7 +45,7 @@ screen_cm_2d = [100, 100]
                 'distance_cm': 1
             },
             TypeError,
-            id='none_screen_cm_raise_type_error'
+            id='none_screen_cm_raises_type_error'
         ),
         pytest.param(
             {
@@ -54,7 +55,7 @@ screen_cm_2d = [100, 100]
                 'distance_cm': None
             },
             TypeError,
-            id='none_distance_cm_raise_type_error'
+            id='none_distance_cm_raises_type_error'
         ),
         pytest.param(
             {
@@ -64,7 +65,7 @@ screen_cm_2d = [100, 100]
                 'distance_cm': 1
             },
             ValueError,
-            id='zero_screen_px_raise_value_error'
+            id='zero_screen_px_raises_value_error'
         ),
         pytest.param(
             {
@@ -74,7 +75,7 @@ screen_cm_2d = [100, 100]
                 'distance_cm': 1
             },
             ValueError,
-            id='zero_screen_cm_raise_value_error'
+            id='zero_screen_cm_raises_value_error'
         ),
         pytest.param(
             {
@@ -84,7 +85,7 @@ screen_cm_2d = [100, 100]
                 'distance_cm': 0
             },
             ValueError,
-            id='zero_distance_cm_raise_value_error'
+            id='zero_distance_cm_raises_value_error'
         ),
         pytest.param(
             {
@@ -106,7 +107,7 @@ screen_cm_2d = [100, 100]
                 'center_origin': False
             },
             ValueError,
-            id='list_coords_2d_screen_px_1d_raise_value_error'
+            id='list_coords_2d_screen_px_1d_raises_value_error'
         ),
         pytest.param(
             {
@@ -117,29 +118,29 @@ screen_cm_2d = [100, 100]
                 'center_origin': False
             },
             ValueError,
-            id='list_coords_2d_screen_cm_1d_raise_value_error'
+            id='list_coords_2d_screen_cm_1d_raises_value_error'
         ),
         pytest.param(
             {
-                'arr': [0]* n_coords,
+                'arr': [0] * n_coords,
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_px_1d,
                 'distance_cm': screen_cm_1d,
                 'center_origin': False
             },
             ValueError,
-            id='list_coords_1d_screen_px_2d_raise_value_error'
+            id='list_coords_1d_screen_px_2d_raises_value_error'
         ),
         pytest.param(
             {
-                'arr': [0]* n_coords,
+                'arr': [0] * n_coords,
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_px_2d,
                 'distance_cm': screen_cm_1d,
                 'center_origin': False
             },
             ValueError,
-            id='list_coords_1d_screen_cm_2d_raise_value_error'
+            id='list_coords_1d_screen_cm_2d_raises_value_error'
         ),
         pytest.param(
             {
@@ -150,11 +151,11 @@ screen_cm_2d = [100, 100]
                 'center_origin': False
             },
             ValueError,
-            id='list_coords_3d_raise_value_error'
+            id='list_coords_3d_raises_value_error'
         )
     ]
 )
-def test_pix2deg_raise_error(kwargs, expected_error):
+def test_pix2deg_raises_error(kwargs, expected_error):
     with pytest.raises(expected_error):
         pix2deg(**kwargs)
 
@@ -171,7 +172,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': False
             },
             0,
-            id='zero_coord_without_center_origin_equals_zero'
+            id='zero_coord_without_center_origin_returns_zero'
         ),
         pytest.param(
             {
@@ -182,7 +183,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': True
             },
             0,
-            id='center_coord_with_center_origin_equals_zero'
+            id='center_coord_with_center_origin_returns_zero'
         ),
         pytest.param(
             {
@@ -193,7 +194,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': False
             },
             45,
-            id='isosceles_triangle_without_center_origin_equals_45'
+            id='isosceles_triangle_without_center_origin_returns_45'
         ),
         pytest.param(
             {
@@ -204,7 +205,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': True
             },
             45,
-            id='isosceles_triangle_with_center_origin_equals_45'
+            id='isosceles_triangle_with_center_origin_returns_45'
         ),
         pytest.param(
             {
@@ -215,7 +216,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': True
             },
             -45,
-            id='isosceles_triangle_left_with_center_origin_equals_minus45'
+            id='isosceles_triangle_left_with_center_origin_returns_minus45'
         ),
         pytest.param(
             {
@@ -226,7 +227,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': False
             },
             45,
-            id='nparray_of_isosceles_triangle_without_center_origin_equals_45'
+            id='nparray_of_isosceles_triangle_without_center_origin_returns_45'
         ),
         pytest.param(
             {
@@ -237,7 +238,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': False
             },
             pytest.approx(26.565, abs=1e-4),
-            id='ankathet_half_without_center_origin_equals_26565'
+            id='ankathet_half_without_center_origin_returns_26565'
         ),
         pytest.param(
             {
@@ -248,7 +249,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': True
             },
             pytest.approx(26.565, abs=1e-4),
-            id='ankathet_half_with_center_origin_equals_26565'
+            id='ankathet_half_with_center_origin_returns_26565'
         ),
         pytest.param(
             {
@@ -259,7 +260,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': False
             },
             pytest.approx(60),
-            id='ankathet_sqrt_3_without_center_origin_equals_60'
+            id='ankathet_sqrt_3_without_center_origin_returns_60'
         ),
         pytest.param(
             {
@@ -270,7 +271,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': True
             },
             pytest.approx(60),
-            id='ankathet_sqrt_3_with_center_origin_equals_60'
+            id='ankathet_sqrt_3_with_center_origin_returns_60'
         ),
         pytest.param(
             {
@@ -281,7 +282,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': False
             },
             pytest.approx(30),
-            id='opposite_sqrt_3_without_center_origin_equals_30'
+            id='opposite_sqrt_3_without_center_origin_returns_30'
         ),
         pytest.param(
             {
@@ -292,7 +293,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
                 'center_origin': True
             },
             pytest.approx(30),
-            id='opposite_sqrt_3_with_center_origin_equals_30'
+            id='opposite_sqrt_3_with_center_origin_returns_30'
         ),
         pytest.param(
             {
@@ -340,7 +341,7 @@ def test_pix2deg_raise_error(kwargs, expected_error):
         )
     ]
 )
-def test_pix2deg_equals(kwargs, expected_value):
+def test_pix2deg_returns(kwargs, expected_value):
     actual_value = pix2deg(**kwargs)
     assert (actual_value == expected_value).all()
 
@@ -354,7 +355,7 @@ def test_pix2deg_equals(kwargs, expected_value):
                 'sampling_rate': 0
             },
             ValueError,
-            id='sampling_rate_zero_raise_value_error'
+            id='sampling_rate_zero_raises_value_error'
         ),
         pytest.param(
             {
@@ -362,7 +363,7 @@ def test_pix2deg_equals(kwargs, expected_value):
                 'sampling_rate': -1
             },
             ValueError,
-            id='sampling_rate_less_zero_raise_value_error'
+            id='sampling_rate_less_zero_raises_value_error'
         ),
         pytest.param(
             {
@@ -370,7 +371,7 @@ def test_pix2deg_equals(kwargs, expected_value):
                 'method': 'smooth'
             },
             ValueError,
-            id='list_length_below_six_method_smooth_raise_value_error'
+            id='list_length_below_six_method_smooth_raises_value_error'
         ),
         pytest.param(
             {
@@ -378,7 +379,7 @@ def test_pix2deg_equals(kwargs, expected_value):
                 'method': 'neighbors'
             },
             ValueError,
-            id='list_length_below_three_method_neighbors_raise_value_error'
+            id='list_length_below_three_method_neighbors_raises_value_error'
         ),
         pytest.param(
             {
@@ -386,7 +387,7 @@ def test_pix2deg_equals(kwargs, expected_value):
                 'method': 'preceding'
             },
             ValueError,
-            id='list_length_below_two_method_preceding_raise_value_error'
+            id='list_length_below_two_method_preceding_raises_value_error'
         ),
         pytest.param(
             {
@@ -398,7 +399,7 @@ def test_pix2deg_equals(kwargs, expected_value):
         )
     ]
 )
-def test_pos2vel_raise_error(kwargs, expected_error):
+def test_pos2vel_raises_error(kwargs, expected_error):
     with pytest.raises(expected_error):
         pos2vel(**kwargs)
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -440,37 +440,29 @@ def test_pos2vel_returns(method, kwargs, padding, expected_value):
     assert (actual_value[padding[0]:padding[1]] == expected_value[padding[0]:padding[1]]).all()
 
 
-def test_pos2vel_stepped_input_returns_alternating_velocity_method_preceding():
+@pytest.mark.parametrize(
+    'method, expected_value',
+    [
+        pytest.param(
+            'preceding', np.array([2.0, 0.0] * (100 // 2)),
+            id='method_preceding_alternating_velocity',
+        ),
+        pytest.param(
+            'neighbors', np.ones((100, )),
+            id='method_neighbors_alternating_velocity',
+        ),
+        pytest.param(
+            'smooth', np.ones((100, )),
+            id='method_smooth_alternating_velocity',
+        ),
+    ]
+)
+def test_pos2vel_stepped_input_returns(method, expected_value):
     N = 100
     x = np.linspace(0, N - 2, N // 2)
     x = np.repeat(x, 2)
 
-    actual_value = pos2vel(x, sampling_rate=1, method='preceding')
-    control_value = np.array([2.0, 0.0] * (N // 2))
+    actual_value = pos2vel(x, sampling_rate=1, method=method)
 
     lpad, rpad = 1, -1
-    assert (actual_value[lpad:rpad] == control_value[lpad:rpad]).all()
-
-
-def test_pos2vel_stepped_input_returns_constant_velocity_method_neighbors():
-    N = 100
-    x = np.linspace(0, N - 2, N // 2)
-    x = np.repeat(x, 2)
-
-    actual_value = pos2vel(x, sampling_rate=1, method='neighbors')
-    control_value = np.ones(x.shape)
-
-    lpad, rpad = 1, -1
-    assert (actual_value[lpad:rpad] == control_value[lpad:rpad]).all()
-
-
-def test_pos2vel_stepped_input_returns_constant_velocity_method_smooth():
-    N = 100
-    x = np.linspace(0, N - 2, N // 2)
-    x = np.repeat(x, 2)
-
-    actual_value = pos2vel(x, sampling_rate=1, method='smooth')
-    control_value = np.ones(x.shape)
-
-    lpad, rpad = 1, -1
-    assert (actual_value[lpad:rpad] == control_value[lpad:rpad]).all()
+    assert (actual_value[lpad:rpad] == expected_value[lpad:rpad]).all()

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -7,262 +7,436 @@ import pytest
 from pymovements.transforms import pix2deg
 from pymovements.transforms import pos2vel
 
-
-def test_pix2deg_none_coords_raise_type_error():
-    with pytest.raises(TypeError):
-        pix2deg(None, 1, 1, 1)
-
-
-def test_pix2deg_none_screen_px_raise_type_error():
-    with pytest.raises(TypeError):
-        pix2deg(0, None, 1, 1)
-
-
-def test_pix2deg_none_screen_cm_raise_type_error():
-    with pytest.raises(TypeError):
-        pix2deg(0, 1, None, 1)
-
-
-def test_pix2deg_none_distance_cm_raise_type_error():
-    with pytest.raises(TypeError):
-        pix2deg(0, 1, 1, None)
-
-
-def test_pix2deg_zero_screen_px_raise_value_error():
-    with pytest.raises(ValueError):
-        pix2deg(0, 0, 1, 1)
-
-
-def test_pix2deg_zero_screen_cm_raise_value_error():
-    with pytest.raises(ValueError):
-        pix2deg(0, 1, 0.0, 1)
-
-
-def test_pix2deg_zero_distance_cm_raise_value_error():
-    with pytest.raises(ValueError):
-        pix2deg(0, 1, 1, 0.0)
-
-
-def test_pix2deg_rank_3_tensor_raises_value_error():
-    with pytest.raises(ValueError):
-        coords = np.zeros((10, 2, 2))
-        pix2deg(coords, [100, 100], [100, 100], 100, False)
-
-
-def test_pix2deg_zero_coord_without_center_origin_equals_zero():
-    assert pix2deg(0, 100, 100, 100, False) == 0
-
-
-def test_pix2deg_center_coord_with_center_origin_equals_zero():
-    screen_px = 100
-    center_px = (screen_px - 1) / 2
-    assert pix2deg(center_px, screen_px, 10, 10, True) == 0
-
-
-def test_pix2deg_isosceles_triangle_without_center_origin_equals_45():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm / 2
-    coord = screen_px / 2
-
-    assert pix2deg(coord, screen_px, screen_cm, distance_cm, False) == 45
-
-
-def test_pix2deg_isosceles_triangle_with_center_origin_equals_45():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm / 2
-    coord = screen_px - 0.5
-
-    assert pix2deg(coord, screen_px, screen_cm, distance_cm, True) == 45
-
-
-def test_pix2deg_isosceles_triangle_left_with_center_origin_equals_minus45():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm / 2
-    coord = -0.5
-
-    assert pix2deg(coord, screen_px, screen_cm, distance_cm, True) == -45
-
-
-def test_pix2deg_ankathet_half_without_center_origin_equals_26565():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm
-    coord = screen_px / 2
-
-    value = pix2deg(coord, screen_px, screen_cm, distance_cm, False)
-    assert value == pytest.approx(26.565, abs=1e-4)
-
-
-def test_pix2deg_ankathet_half_with_center_origin_equals_26565():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm
-    coord = screen_px - 0.5
-
-    value = pix2deg(coord, screen_px, screen_cm, distance_cm, True)
-    assert value == pytest.approx(26.565, abs=1e-4)
-
-
-def test_pix2deg_ankathet_sqrt_3_without_center_origin_equals_60():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm / 2 / np.sqrt(3)
-    coord = screen_px / 2
-
-    assert (
-        pix2deg(coord, screen_px, screen_cm, distance_cm, False)
-        == pytest.approx(60)
-    )
-
-
-def test_pix2deg_ankathet_sqrt_3_with_center_origin_equals_60():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm / 2 / np.sqrt(3)
-    coord = screen_px - 0.5
-
-    assert (
-        pix2deg(coord, screen_px, screen_cm, distance_cm, True)
-        == pytest.approx(60)
-    )
-
-
-def test_pix2deg_opposite_sqrt_3_without_center_origin_equals_30():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm / 2 * np.sqrt(3)
-    coord = screen_px / 2
-
-    actual_value = pix2deg(coord, screen_px, screen_cm, distance_cm, False)
-    assert actual_value == pytest.approx(30)
-
-
-def test_pix2deg_opposite_sqrt_3_with_center_origin_equals_30():
-    screen_px = 100
-    screen_cm = 100
-    distance_cm = screen_cm / 2 * np.sqrt(3)
-    coord = screen_px - 0.5
-
-    actual_value = pix2deg(coord, screen_px, screen_cm, distance_cm, True)
-    assert actual_value == pytest.approx(30)
-
-
-def test_pix2deg_list_of_zero_coords_1d():
-    n_coords = 10
-    coords = [0] * n_coords
-    control = np.array([0.0] * n_coords)
-    actual = pix2deg(coords, 100, 100, 100, False)
-    assert (control == actual).all()
-
-
-def test_pix2deg_nparray_of_zero_coords_1d():
-    n_coords = 10
-    coords = np.array([0] * n_coords)
-    control = np.array([0.0] * n_coords)
-    actual = pix2deg(coords, 100, 100, 100, False)
-    assert (control == actual).all()
-
-
-def test_pix2deg_list_of_zero_coords_2d():
-    n_coords = 10
-    coords = [[0, 0]] * n_coords
-    control = np.array([[0.0, 0.0]] * n_coords)
-    actual = pix2deg(coords, [100, 100], [100, 100], 100, False)
-    assert (control == actual).all()
-
-
-def test_pix2deg_list_of_zero_coords_2d_screen_px_1d_raise_value_error():
-    n_coords = 10
-    coords = [[0, 0]] * n_coords
-    with pytest.raises(ValueError):
-        pix2deg(coords, 100, [100, 100], 100, False)
-
-
-def test_pix2deg_list_of_zero_coords_2d_screen_cm_1d_raise_value_error():
-    n_coords = 10
-    coords = [[0, 0]] * n_coords
-    with pytest.raises(ValueError):
-        pix2deg(coords, [100, 100], 100, 100, False)
-
-
-def test_pix2deg_nparray_of_isosceles_triangle_without_center_origin_equals_45():
-    screen_px = [100, 100]
-    screen_cm = [100, 100]
-    distance_cm = screen_cm[0] / 2
-    coord = screen_px[0] / 2 * np.ones((10, 2))
-
-    control = 45
-    actual = pix2deg(coord, screen_px, screen_cm, distance_cm, False)
-    assert (actual == control).all()
-
-
-def test_pix2deg_list_1d_screen_px_2d_raise_value_error():
-    with pytest.raises(ValueError):
-        pix2deg([0] * 10, [100, 100], 100, 100)
-
-
-def test_pix2deg_list_1d_screen_cm_2d_raise_value_error():
-    with pytest.raises(ValueError):
-        pix2deg([0] * 10, 100, [100, 100], 100)
-
-
-def test_pix2deg_list_3d_raise_value_error():
-    with pytest.raises(ValueError):
-        pix2deg(np.zeros((10, 3)), [1, 1, 1], [1, 1, 1], 1)
-
-
-def test_pos2vel_sampling_rate_zero_raise_value_error():
-    with pytest.raises(ValueError):
-        pos2vel([0]*10, sampling_rate=0)
-
-
-def test_pos2vel_sampling_rate_less_zero_raise_value_error():
-    with pytest.raises(ValueError):
-        pos2vel([0]*10, sampling_rate=-1)
-
-
-def test_pos2vel_list_length_below_six_method_smooth_raise_value_error():
-    with pytest.raises(ValueError):
-        pos2vel([0]*5, method='smooth')
-
-
-def test_pos2vel_list_length_below_six_method_neighbors_raise_value_error():
-    with pytest.raises(ValueError):
-        pos2vel([0]*2, method='neighbors')
-
-
-def test_pos2vel_list_length_below_six_method_preceding_raise_value_error():
-    with pytest.raises(ValueError):
-        pos2vel([0], method='preceding')
-
-
-def test_pos2vel_invalid_method_raises_value_error():
-    with pytest.raises(ValueError):
-        pos2vel([0]*10, method='invalid')
-
-
-@pytest.mark.parametrize('method', ['smooth', 'neighbors', 'preceding'])
-def test_pos2vel_constant_input_returns_zero_velocity(method):
-    N = 10
-    x = np.repeat(0, N)
-    actual_value = pos2vel(x, sampling_rate=1, method=method)
-    control_value = np.zeros(x.shape)
-
-    assert (actual_value == control_value).all()
-
-
-@pytest.mark.parametrize('method', ['smooth', 'neighbors', 'preceding'])
-def test_pos2vel_linear_input_returns_constant_velocity(method):
-    N = 100
-    x = np.linspace(0, N - 1, N)
-    actual_value = pos2vel(x, sampling_rate=1, method=method)
-    control_value = np.ones(x.shape)
-
-    lpad, rpad = 1, -1
-    assert (actual_value[lpad:rpad] == control_value[lpad:rpad]).all()
+n_coords = 100
+screen_px_1d = 100
+screen_cm_1d = 100
+screen_px_2d = [100, 100]
+screen_cm_2d = [100, 100]
+
+@pytest.mark.parametrize(
+    'kwargs, expected_error',
+    [
+        pytest.param(
+            {
+                'arr': None,
+                'screen_px': 1,
+                'screen_cm': 1,
+                'distance_cm': 1
+            },
+            TypeError,
+            id='none_coords_raise_type_error'
+        ),
+        pytest.param(
+            {
+                'arr': 0,
+                'screen_px': None,
+                'screen_cm': 1,
+                'distance_cm': 1
+            },
+            TypeError,
+            id='none_screen_px_raise_type_error'
+        ),
+        pytest.param(
+            {
+                'arr': 0,
+                'screen_px': 1,
+                'screen_cm': None,
+                'distance_cm': 1
+            },
+            TypeError,
+            id='none_screen_cm_raise_type_error'
+        ),
+        pytest.param(
+            {
+                'arr': 0,
+                'screen_px': 1,
+                'screen_cm': 1,
+                'distance_cm': None
+            },
+            TypeError,
+            id='none_distance_cm_raise_type_error'
+        ),
+        pytest.param(
+            {
+                'arr': 0,
+                'screen_px': 0,
+                'screen_cm': 1,
+                'distance_cm': 1
+            },
+            ValueError,
+            id='zero_screen_px_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': 0,
+                'screen_px': 1,
+                'screen_cm': 0,
+                'distance_cm': 1
+            },
+            ValueError,
+            id='zero_screen_cm_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': 0,
+                'screen_px': 1,
+                'screen_cm': 1,
+                'distance_cm': 0
+            },
+            ValueError,
+            id='zero_distance_cm_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': np.zeros((10, 2, 2)),
+                'screen_px': screen_px_2d,
+                'screen_cm': screen_cm_2d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            ValueError,
+            id='rank_3_tensor_raises_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [[0, 0]] * n_coords,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_px_2d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            ValueError,
+            id='list_coords_2d_screen_px_1d_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [[0, 0]] * n_coords,
+                'screen_px': screen_px_2d,
+                'screen_cm': screen_px_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            ValueError,
+            id='list_coords_2d_screen_cm_1d_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [0]* n_coords,
+                'screen_px': screen_px_2d,
+                'screen_cm': screen_px_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            ValueError,
+            id='list_coords_1d_screen_px_2d_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [0]* n_coords,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_px_2d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            ValueError,
+            id='list_coords_1d_screen_cm_2d_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': np.zeros((n_coords, 3)),
+                'screen_px': [1, 1, 1],
+                'screen_cm': [1, 1, 1],
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            ValueError,
+            id='list_coords_3d_raise_value_error'
+        )
+    ]
+)
+def test_pix2deg_raise_error(kwargs, expected_error):
+    with pytest.raises(expected_error):
+        pix2deg(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected_value',
+    [
+        pytest.param(
+            {
+                'arr': 0,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            0,
+            id='zero_coord_without_center_origin_equals_zero'
+        ),
+        pytest.param(
+            {
+                'arr': (screen_px_1d - 1) / 2,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': True
+            },
+            0,
+            id='center_coord_with_center_origin_equals_zero'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d / 2,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d / 2,
+                'center_origin': False
+            },
+            45,
+            id='isosceles_triangle_without_center_origin_equals_45'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d - 0.5,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d / 2,
+                'center_origin': True
+            },
+            45,
+            id='isosceles_triangle_with_center_origin_equals_45'
+        ),
+        pytest.param(
+            {
+                'arr': -0.5,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d / 2,
+                'center_origin': True
+            },
+            -45,
+            id='isosceles_triangle_left_with_center_origin_equals_minus45'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_2d[0] / 2 * np.ones((n_coords, 2)),
+                'screen_px': screen_px_2d,
+                'screen_cm': screen_cm_2d,
+                'distance_cm': screen_px_2d[0] / 2,
+                'center_origin': False
+            },
+            45,
+            id='nparray_of_isosceles_triangle_without_center_origin_equals_45'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d / 2,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            pytest.approx(26.565, abs=1e-4),
+            id='ankathet_half_without_center_origin_equals_26565'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d - 0.5,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': True
+            },
+            pytest.approx(26.565, abs=1e-4),
+            id='ankathet_half_with_center_origin_equals_26565'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d / 2,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d / 2 / np.sqrt(3),
+                'center_origin': False
+            },
+            pytest.approx(60),
+            id='ankathet_sqrt_3_without_center_origin_equals_60'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d - 0.5,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d / 2 / np.sqrt(3),
+                'center_origin': True
+            },
+            pytest.approx(60),
+            id='ankathet_sqrt_3_with_center_origin_equals_60'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d / 2,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d / 2 * np.sqrt(3),
+                'center_origin': False
+            },
+            pytest.approx(30),
+            id='opposite_sqrt_3_without_center_origin_equals_30'
+        ),
+        pytest.param(
+            {
+                'arr': screen_px_1d - 0.5,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d / 2 * np.sqrt(3),
+                'center_origin': True
+            },
+            pytest.approx(30),
+            id='opposite_sqrt_3_with_center_origin_equals_30'
+        ),
+        pytest.param(
+            {
+                'arr': [0] * n_coords,
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            np.array([0.0] * n_coords),
+            id='list_of_zero_coords_1d'
+        ),
+        pytest.param(
+            {
+                'arr': np.array([0] * n_coords),
+                'screen_px': screen_px_1d,
+                'screen_cm': screen_cm_1d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            np.array([0.0] * n_coords),
+            id='nparray_of_zero_coords_1d'
+        ),
+        pytest.param(
+            {
+                'arr': [[0, 0]] * n_coords,
+                'screen_px': screen_px_2d,
+                'screen_cm': screen_cm_2d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            np.array([[0.0, 0.0]] * n_coords),
+            id='list_of_zero_coords_2d'
+        ),
+        pytest.param(
+            {
+                'arr': np.array([[0, 0]] * n_coords),
+                'screen_px': screen_px_2d,
+                'screen_cm': screen_cm_2d,
+                'distance_cm': screen_cm_1d,
+                'center_origin': False
+            },
+            np.array([[0.0, 0.0]] * n_coords),
+            id='nparray_of_zero_coords_2d'
+        )
+    ]
+)
+def test_pix2deg_equals(kwargs, expected_value):
+    actual_value = pix2deg(**kwargs)
+    assert (actual_value == expected_value).all()
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected_error',
+    [
+        pytest.param(
+            {
+                'arr': [[0] * 10],
+                'sampling_rate': 0
+            },
+            ValueError,
+            id='sampling_rate_zero_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [[0] * 10],
+                'sampling_rate': -1
+            },
+            ValueError,
+            id='sampling_rate_less_zero_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [0] * 5,
+                'method': 'smooth'
+            },
+            ValueError,
+            id='list_length_below_six_method_smooth_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [0] * 2,
+                'method': 'neighbors'
+            },
+            ValueError,
+            id='list_length_below_three_method_neighbors_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [0],
+                'method': 'preceding'
+            },
+            ValueError,
+            id='list_length_below_two_method_preceding_raise_value_error'
+        ),
+        pytest.param(
+            {
+                'arr': [0] * 10,
+                'method': 'invalid'
+            },
+            ValueError,
+            id='invalid_method_raises_value_error'
+        )
+    ]
+)
+def test_pos2vel_raise_error(kwargs, expected_error):
+    with pytest.raises(expected_error):
+        pos2vel(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'method',
+    [
+        pytest.param('smooth', id='method_smooth'),
+        pytest.param('neighbors', id='method_neighbors'),
+        pytest.param('preceding', id='method_preceding')
+    ]
+)
+@pytest.mark.parametrize(
+    'kwargs, padding, expected_value',
+    [
+        pytest.param(
+            {
+                'arr': np.repeat(0, n_coords),
+                'sampling_rate': 1
+            },
+            (0, n_coords),
+            np.zeros(n_coords),
+            id='constant_input_returns_zero_velocity'
+        ),
+        pytest.param(
+            {
+                'arr': np.linspace(0, n_coords - 1, n_coords),
+                'sampling_rate': 1
+            },
+            (1, -1),
+            np.ones(n_coords),
+            id='linear_input_returns_constant_velocity'
+        )
+    ]
+)
+def test_pos2vel_returns(method, kwargs, padding, expected_value):
+    actual_value = pos2vel(**kwargs, method=method)
+    assert (actual_value[padding[0]:padding[1]] == expected_value[padding[0]:padding[1]]).all()
 
 
 def test_pos2vel_stepped_input_returns_alternating_velocity_method_preceding():
@@ -271,7 +445,7 @@ def test_pos2vel_stepped_input_returns_alternating_velocity_method_preceding():
     x = np.repeat(x, 2)
 
     actual_value = pos2vel(x, sampling_rate=1, method='preceding')
-    control_value = np.array([2.0, 0.0] * (N//2))
+    control_value = np.array([2.0, 0.0] * (N // 2))
 
     lpad, rpad = 1, -1
     assert (actual_value[lpad:rpad] == control_value[lpad:rpad]).all()


### PR DESCRIPTION
## Description

Merged the single tests for `transforms.pos2vel` and `transforms.deg2vel` into one test by pytest parametrization:

## Implemented changes
- `test_pix2deg_raise_error` function for `pix2deg` raising error `expected_error` with input `kwargs`
- `test_pos2vel_raise_error` function for `pos2vel` raising error `expected_error` with input `kwargs`
- `test_pix2deg_equals` to check if `pix2deg` returns `expected_value` with input `kwargs` 
- `test_pos2vel_returns` to check if `pos2vel` returns `expected_value` with input `kwargs` and calculation method `method`


