### PR TITLE
remove type from tests/events/test_events_base.py to conform with rest of test suite

### DIFF
--- a/tests/events/test_events_base.py
+++ b/tests/events/test_events_base.py
@@ -1,9 +1,6 @@
 """
 This module tests functionality of base event classes.
 """
-from __future__ import annotations
-from typing import Any
-
 import pytest
 
 from pymovements.events import Event
@@ -41,7 +38,9 @@ from pymovements.events import Saccade
         ),
     ]
 )
-def test_event_class(event_class: Event, init_params: dict[str, Any], expected: dict[str, Any]):
+def test_event_class(
+    event_class, init_params, expected,
+):
     """Test if instantiated event attributes fit expected values."""
     event = event_class(**init_params)
 


### PR DESCRIPTION

## Description
I removed type hints from one test file to match the rest of the tests -- generally I think we do not need to type tests because we're checking type hints with type checkers and tests are for functionality. functionallity should fail given the wrong type.

## Implemented changes
- Insert a description of the changes implemented in the pull request.
  - [x] removed typing hint from tests/events/test_events_base.py 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
