### PR TITLE
Utils: fix bug in get_filepaths()

### DIFF
--- a/src/pymovements/utils/paths.py
+++ b/src/pymovements/utils/paths.py
@@ -45,7 +45,7 @@ def get_filepaths(
     filepaths = []
     for childpath in rootpath.iterdir():
         if childpath.is_dir():
-            filepaths.extend(get_filepaths(childpath, extension))
+            filepaths.extend(get_filepaths(rootpath=childpath, extension=extension, regex=regex))
         else:
             # if extension specified and not matching, continue to next
             if extension and childpath.suffix != extension:


### PR DESCRIPTION
## Description

While working on the new datasets feature I discovered a bug in `get_filepaths()`:
The explicitly passed regex wasn't passed to the recursive call, so basically all files were listed.

## Implemented changes

- [x] pass all arguments forward to the recursive call

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is really a good case that we should add much more tests to the utils functions.
I'm not sure how to test such functionality correctly, maybe creating some arbitrary folder structure?

Unfortunately I don't have much time for creating tests for this, but I will create an issue later.
So no additional tests unfortunately, due to the tight schedule for the warsaw meeting :(

I'm feeling bad already. 🥺