### PR TITLE
Docs: change documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ interface to download publicly available datasets, preprocess gaze data, detect 
 and render plots to visually analyze your results. 
 
 - **Website:** https://github.com/aeye-lab/pymovements
-- **Documentation:** https://readthedocs.org/projects/pymovements
+- **Documentation:** https://pymovements.readthedocs.io
 - **Source code:** https://github.com/aeye-lab/pymovements
 - **Contributing:** https://github.com/aeye-lab/pymovements/blob/main/CONTRIBUTING.md
 - **Bug reports:** https://github.com/aeye-lab/pymovements/issues


### PR DESCRIPTION
Documentation link was leading to the whole project where the user would have to click on the correct version etc.

Now we automatically lead to the version of the last stable version and have a much more memorizable URL.