### PR TITLE
CI: add mypy to checks and run checks only on linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,12 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
           - ubuntu-latest
-          - windows-latest
         tox_env:
           - flake8
           - pylint
+          - mypy
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,6 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 
 [testenv:mypy]
-basepython = python3.8
 changedir = {toxinidir}
 deps =
     mypy


### PR DESCRIPTION
## Description

mypy was missing from checks so now I added these.
I also removed macos and windows from the flake8, pylint, and mypy checking, as these are platform independent and therefore redundant.