### PR TITLE
CI: fix pylint deprecation warning

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -509,7 +509,7 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception
 
 
 [TYPING]


### PR DESCRIPTION
overgeneral-exceptions must specify parent-module.