### PR TITLE
CI: Add src to pytest testpaths for running doctests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -96,8 +96,10 @@ max-line-length = 100
 
 
 [pytest]
-testpaths = tests
-addopts = -ra -l --doctest-modules
+testpaths =
+    tests
+    src
+addopts = -ra -l -v --doctest-modules
 filterwarnings =
     ignore::DeprecationWarning:pkg_resources.*:
 


### PR DESCRIPTION
This way it is possible to simply run `pytest` and it will include the doctests too.

I will add some in-detail description on this to the CONTRIBUTION.md, as developers don't need to run tests for all python environments during development process.