### PR TITLE
Transforms: refactor center_origin to origin in pix2deg()

### DIFF
--- a/src/pymovements/base.py
+++ b/src/pymovements/base.py
@@ -65,7 +65,7 @@ class Screen:
         distance_cm : float
             Eye-to-screen distance in centimeters
         origin : str
-            Specifies the origin location of pixel coordinates.
+            Specifies the screen location of the origin in the pixel coordinate system.
 
         Examples
         --------
@@ -178,7 +178,7 @@ class Experiment:
         distance_cm : float
             Eye-to-screen distance in centimeters
         origin : str
-            Specifies the origin location of pixel coordinates.
+            Specifies the screen location of the origin in the pixel coordinate system.
         sampling_rate : float
             Sampling rate in Hz
 

--- a/src/pymovements/base.py
+++ b/src/pymovements/base.py
@@ -29,7 +29,7 @@ class Screen:
     distance_cm : float
         Eye-to-screen distance in centimeters
     origin : str
-        Specifies the origin location of pixel coordinates.
+        Specifies the screen location of the origin in the pixel coordinate system.
     x_max_dva : float
         Maximum screen x-coordinate in degrees of visual angle
     y_max_dva : float

--- a/src/pymovements/base.py
+++ b/src/pymovements/base.py
@@ -18,7 +18,6 @@ class Screen:
 
     Attributes
     ----------
-
     width_px : int
         Screen width in pixels
     height_px : int
@@ -29,6 +28,8 @@ class Screen:
         Screen height in centimeters
     distance_cm : float
         Eye-to-screen distance in centimeters
+    origin : str
+        Specifies the origin location of pixel coordinates.
     x_max_dva : float
         Maximum screen x-coordinate in degrees of visual angle
     y_max_dva : float
@@ -40,7 +41,13 @@ class Screen:
 
     """
     def __init__(
-        self, width_px: int, height_px: int, width_cm: float, height_cm: float, distance_cm: float,
+        self,
+        width_px: int,
+        height_px: int,
+        width_cm: float,
+        height_cm: float,
+        distance_cm: float,
+        origin: str,
     ):
         """
         Initializes Screen.
@@ -57,6 +64,8 @@ class Screen:
             Screen height in centimeters
         distance_cm : float
             Eye-to-screen distance in centimeters
+        origin : str
+            Specifies the origin location of pixel coordinates.
 
         Examples
         --------
@@ -66,10 +75,11 @@ class Screen:
         ...     width_cm=38,
         ...     height_cm=30,
         ...     distance_cm=68,
+        ...     origin='lower left',
         ... )
         >>> print(screen)  # doctest: +NORMALIZE_WHITESPACE
         Screen(width_px=1280, height_px=1024, width_cm=38, height_cm=30, distance_cm=68,
-         x_max_dva=15.60, y_max_dva=12.43, x_min_dva=-15.60, y_min_dva=-12.43)
+        origin=lower left, x_max_dva=15.60, y_max_dva=12.43, x_min_dva=-15.60, y_min_dva=-12.43)
 
         """
         checks.check_no_zeros(width_px, "width_px")
@@ -83,17 +93,17 @@ class Screen:
         self.width_cm = width_cm
         self.height_cm = height_cm
         self.distance_cm = distance_cm
+        self.origin = origin
 
         # calculate screen boundary coordinates in degrees of visual angle
-        self.x_max_dva = pix2deg(width_px-1, width_px, width_cm, distance_cm)
-        self.y_max_dva = pix2deg(height_px-1, height_px, height_cm, distance_cm)
-        self.x_min_dva = pix2deg(0, width_px, width_cm, distance_cm)
-        self.y_min_dva = pix2deg(0, height_px, height_cm, distance_cm)
+        self.x_max_dva = pix2deg(width_px-1, width_px, width_cm, distance_cm, origin=origin)
+        self.y_max_dva = pix2deg(height_px-1, height_px, height_cm, distance_cm, origin=origin)
+        self.x_min_dva = pix2deg(0, width_px, width_cm, distance_cm, origin=origin)
+        self.y_min_dva = pix2deg(0, height_px, height_cm, distance_cm, origin=origin)
 
     def pix2deg(
             self,
             arr: float | list[float] | list[list[float]] | np.ndarray,
-            center_origin: bool = True,
     ) -> np.ndarray:
         """
         Converts pixel screen coordinates to degrees of visual angle.
@@ -102,8 +112,6 @@ class Screen:
         ----------
         arr : float, array_like
             Pixel coordinates to transform into degrees of visual angle
-        center_origin: bool
-            Center origin to (0,0) if positions origin is in bottom left corner
 
         Returns
         -------
@@ -123,6 +131,7 @@ class Screen:
         ...     width_cm=38,
         ...     height_cm=30,
         ...     distance_cm=68,
+        ...     origin='lower left',
         ... )
         """
         return pix2deg(
@@ -130,7 +139,7 @@ class Screen:
             screen_px=(self.width_px, self.height_px),
             screen_cm=(self.width_cm, self.height_cm),
             distance_cm=self.distance_cm,
-            center_origin=center_origin,
+            origin=self.origin,
         )
 
 
@@ -150,7 +159,7 @@ class Experiment:
     def __init__(
         self, screen_width_px: int, screen_height_px: int,
         screen_width_cm: float, screen_height_cm: float,
-        distance_cm: float, sampling_rate: float,
+        distance_cm: float, origin: str, sampling_rate: float,
     ):
         """
         Initializes Experiment.
@@ -168,6 +177,8 @@ class Experiment:
             Screen height in centimeters
         distance_cm : float
             Eye-to-screen distance in centimeters
+        origin : str
+            Specifies the origin location of pixel coordinates.
         sampling_rate : float
             Sampling rate in Hz
 
@@ -178,5 +189,6 @@ class Experiment:
             width_cm=screen_width_cm,
             height_cm=screen_height_cm,
             distance_cm=distance_cm,
+            origin=origin,
         )
         self.sampling_rate = sampling_rate

--- a/src/pymovements/base.py
+++ b/src/pymovements/base.py
@@ -29,7 +29,7 @@ class Screen:
     distance_cm : float
         Eye-to-screen distance in centimeters
     origin : str
-        Specifies the screen location of the origin in the pixel coordinate system.
+        Specifies the screen location of the origin of the pixel coordinate system.
     x_max_dva : float
         Maximum screen x-coordinate in degrees of visual angle
     y_max_dva : float
@@ -65,7 +65,7 @@ class Screen:
         distance_cm : float
             Eye-to-screen distance in centimeters
         origin : str
-            Specifies the screen location of the origin in the pixel coordinate system.
+            Specifies the screen location of the origin of the pixel coordinate system.
 
         Examples
         --------
@@ -178,7 +178,7 @@ class Experiment:
         distance_cm : float
             Eye-to-screen distance in centimeters
         origin : str
-            Specifies the screen location of the origin in the pixel coordinate system.
+            Specifies the screen location of the origin of the pixel coordinate system.
         sampling_rate : float
             Sampling rate in Hz
 

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -35,7 +35,7 @@ def pix2deg(
 
     Returns
     -------
-    degrees_of_visual_angle : np.ndarray
+    np.ndarray
         Coordinates in degrees of visual angle
 
     Raises
@@ -60,7 +60,7 @@ def pix2deg(
     screen_px = np.array(screen_px)
     screen_cm = np.array(screen_cm)
 
-    # check basic arr dimensions
+    # Check basic arr dimensions.
     if arr.ndim not in [0, 1, 2]:
         raise ValueError(
             'Number of dimensions of arr must be either 0, 1 or 2'
@@ -89,20 +89,20 @@ def pix2deg(
         if screen_cm.shape != (2,):
             raise ValueError('arr is 4-dimensional, but screen_cm is not 2-dimensional')
 
-        # we have binocular data. double tile screen parameters.
+        # We have binocular data. Double tile screen parameters.
         screen_px = np.tile(screen_px, 2)
         screen_cm = np.tile(screen_cm, 2)
 
-    # compute eye-to-screen-distance in pixels
+    # Compute eye-to-screen-distance in pixels.
     distance_px = distance_cm * (screen_px / screen_cm)
 
-    # center screen coordinates such that 0 is in the center of the screen
+    # If pixel coordinate system is not centered, shift pixel coordinate to the center.
     if origin == "lower left":
         arr = arr - (screen_px - 1) / 2
     elif origin != "center":
         raise ValueError(f"origin {origin} is not supported.")
 
-    # 180 / pi transforms arc measure to degrees
+    # 180 / pi transforms arc measure to degrees.
     return np.arctan2(arr, distance_px) * 180 / np.pi
 
 
@@ -136,7 +136,7 @@ def pos2vel(
 
     Returns
     -------
-    velocities : array_like
+    np.ndarray
         Velocity time series in input_unit / sec
 
     Raises

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -31,7 +31,8 @@ def pix2deg(
     distance_cm : float
         Eye-to-screen distance in centimeters
     origin : str
-        Specifies the origin location of pixel coordinates. Valid values are: center, lower left.
+        Specifies the screen location of the origin in the pixel coordinate system. Valid values
+        are: center, lower left.
 
     Returns
     -------

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -40,6 +40,8 @@ def pix2deg(
 
     Raises
     ------
+    TypeError
+        If arr is None.
     ValueError
         If dimension screen_px or screen_cm don't match dimension of arr.
         If screen_px or screen_cm or one of its elements is zero.

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -16,7 +16,7 @@ def pix2deg(
         screen_px: float | list[float] | tuple[float, float] | np.ndarray,
         screen_cm: float | list[float] | tuple[float, float] | np.ndarray,
         distance_cm: float,
-        center_origin: bool = True,
+        origin: str,
 ) -> np.ndarray:
     """Converts pixel screen coordinates to degrees of visual angle.
 
@@ -30,8 +30,8 @@ def pix2deg(
         Screen dimension in centimeters
     distance_cm : float
         Eye-to-screen distance in centimeters
-    center_origin: bool
-        Center origin to (0,0) if arr origin is in bottom left corner
+    origin : str
+        Specifies the origin location of pixel coordinates. Valid values are: center, lower left.
 
     Returns
     -------
@@ -44,8 +44,12 @@ def pix2deg(
         If dimension screen_px or screen_cm don't match dimension of arr.
         If screen_px or screen_cm or one of its elements is zero.
         If distance_cm is zero.
+        If origin value is not supported.
 
     """
+    if arr is None:
+        raise TypeError("arr must not be None")
+
     checks.check_no_zeros(screen_px, "screen_px")
     checks.check_no_zeros(screen_cm, "screen_px")
     checks.check_no_zeros(distance_cm, "distance_cm")
@@ -91,8 +95,10 @@ def pix2deg(
     distance_px = distance_cm * (screen_px / screen_cm)
 
     # center screen coordinates such that 0 is in the center of the screen
-    if center_origin:
+    if origin == "lower left":
         arr = arr - (screen_px - 1) / 2
+    elif origin != "center":
+        raise ValueError(f"origin {origin} is not supported.")
 
     # 180 / pi transforms arc measure to degrees
     return np.arctan2(arr, distance_px) * 180 / np.pi

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -31,7 +31,7 @@ def pix2deg(
     distance_cm : float
         Eye-to-screen distance in centimeters
     origin : str
-        Specifies the screen location of the origin in the pixel coordinate system. Valid values
+        Specifies the screen location of the origin of the pixel coordinate system. Valid values
         are: center, lower left.
 
     Returns

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -23,7 +23,8 @@ screen_cm_2d = [100, 100]
                 'arr': None,
                 'screen_px': 1,
                 'screen_cm': 1,
-                'distance_cm': 1
+                'distance_cm': 1,
+                'origin': 'center',
             },
             TypeError,
             id='none_coords_raises_type_error'
@@ -33,7 +34,8 @@ screen_cm_2d = [100, 100]
                 'arr': 0,
                 'screen_px': None,
                 'screen_cm': 1,
-                'distance_cm': 1
+                'distance_cm': 1,
+                'origin': 'center',
             },
             TypeError,
             id='none_screen_px_raises_type_error'
@@ -43,7 +45,8 @@ screen_cm_2d = [100, 100]
                 'arr': 0,
                 'screen_px': 1,
                 'screen_cm': None,
-                'distance_cm': 1
+                'distance_cm': 1,
+                'origin': 'center',
             },
             TypeError,
             id='none_screen_cm_raises_type_error'
@@ -53,7 +56,8 @@ screen_cm_2d = [100, 100]
                 'arr': 0,
                 'screen_px': 1,
                 'screen_cm': 1,
-                'distance_cm': None
+                'distance_cm': None,
+                'origin': 'center',
             },
             TypeError,
             id='none_distance_cm_raises_type_error'
@@ -63,7 +67,8 @@ screen_cm_2d = [100, 100]
                 'arr': 0,
                 'screen_px': 0,
                 'screen_cm': 1,
-                'distance_cm': 1
+                'distance_cm': 1,
+                'origin': 'center',
             },
             ValueError,
             id='zero_screen_px_raises_value_error'
@@ -73,7 +78,8 @@ screen_cm_2d = [100, 100]
                 'arr': 0,
                 'screen_px': 1,
                 'screen_cm': 0,
-                'distance_cm': 1
+                'distance_cm': 1,
+                'origin': 'center',
             },
             ValueError,
             id='zero_screen_cm_raises_value_error'
@@ -83,7 +89,8 @@ screen_cm_2d = [100, 100]
                 'arr': 0,
                 'screen_px': 1,
                 'screen_cm': 1,
-                'distance_cm': 0
+                'distance_cm': 0,
+                'origin': 'center',
             },
             ValueError,
             id='zero_distance_cm_raises_value_error'
@@ -94,7 +101,7 @@ screen_cm_2d = [100, 100]
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_cm_2d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             ValueError,
             id='rank_3_tensor_raises_value_error'
@@ -105,7 +112,7 @@ screen_cm_2d = [100, 100]
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_px_2d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             ValueError,
             id='list_coords_2d_screen_px_1d_raises_value_error'
@@ -116,7 +123,7 @@ screen_cm_2d = [100, 100]
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_px_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             ValueError,
             id='list_coords_2d_screen_cm_1d_raises_value_error'
@@ -127,7 +134,7 @@ screen_cm_2d = [100, 100]
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_px_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             ValueError,
             id='list_coords_1d_screen_px_2d_raises_value_error'
@@ -138,7 +145,7 @@ screen_cm_2d = [100, 100]
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_px_2d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             ValueError,
             id='list_coords_1d_screen_cm_2d_raises_value_error'
@@ -149,7 +156,7 @@ screen_cm_2d = [100, 100]
                 'screen_px': [1, 1, 1],
                 'screen_cm': [1, 1, 1],
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             ValueError,
             id='list_coords_3d_raises_value_error'
@@ -170,7 +177,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             0,
             id='zero_coord_without_center_origin_returns_zero'
@@ -181,7 +188,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': True
+                'origin': 'lower left',
             },
             0,
             id='center_coord_with_center_origin_returns_zero'
@@ -192,7 +199,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d / 2,
-                'center_origin': False
+                'origin': 'center',
             },
             45,
             id='isosceles_triangle_without_center_origin_returns_45'
@@ -203,7 +210,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d / 2,
-                'center_origin': True
+                'origin': 'lower left',
             },
             45,
             id='isosceles_triangle_with_center_origin_returns_45'
@@ -214,7 +221,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d / 2,
-                'center_origin': True
+                'origin': 'lower left',
             },
             -45,
             id='isosceles_triangle_left_with_center_origin_returns_minus45'
@@ -225,7 +232,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_cm_2d,
                 'distance_cm': screen_px_2d[0] / 2,
-                'center_origin': False
+                'origin': 'center',
             },
             45,
             id='nparray_of_isosceles_triangle_without_center_origin_returns_45'
@@ -236,7 +243,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             pytest.approx(26.565, abs=1e-4),
             id='ankathet_half_without_center_origin_returns_26565'
@@ -247,7 +254,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': True
+                'origin': 'lower left',
             },
             pytest.approx(26.565, abs=1e-4),
             id='ankathet_half_with_center_origin_returns_26565'
@@ -258,7 +265,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d / 2 / np.sqrt(3),
-                'center_origin': False
+                'origin': 'center',
             },
             pytest.approx(60),
             id='ankathet_sqrt_3_without_center_origin_returns_60'
@@ -269,7 +276,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d / 2 / np.sqrt(3),
-                'center_origin': True
+                'origin': 'lower left',
             },
             pytest.approx(60),
             id='ankathet_sqrt_3_with_center_origin_returns_60'
@@ -280,7 +287,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d / 2 * np.sqrt(3),
-                'center_origin': False
+                'origin': 'center',
             },
             pytest.approx(30),
             id='opposite_sqrt_3_without_center_origin_returns_30'
@@ -291,7 +298,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d / 2 * np.sqrt(3),
-                'center_origin': True
+                'origin': 'lower left',
             },
             pytest.approx(30),
             id='opposite_sqrt_3_with_center_origin_returns_30'
@@ -302,7 +309,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             np.array([0.0] * n_coords),
             id='list_of_zero_coords_1d'
@@ -313,7 +320,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_1d,
                 'screen_cm': screen_cm_1d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             np.array([0.0] * n_coords),
             id='nparray_of_zero_coords_1d'
@@ -324,7 +331,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_cm_2d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             np.array([[0.0, 0.0]] * n_coords),
             id='list_of_zero_coords_2d'
@@ -335,7 +342,7 @@ def test_pix2deg_raises_error(kwargs, expected_error):
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_cm_2d,
                 'distance_cm': screen_cm_1d,
-                'center_origin': False
+                'origin': 'center',
             },
             np.array([[0.0, 0.0]] * n_coords),
             id='nparray_of_zero_coords_2d'


### PR DESCRIPTION
This PR changes some functionality from `pix2deg()`.

Before, `center_origin` was used to center pixel coordinates from the lower left to the center.
Now we have an `origin` argument to specify the location of the origin.
The meaning of the argument is much more understandable this way.
This way we will also be more flexible in the future.

Currently we still only support two cases:

- `center` which is the same as `center_origin=False` 
- `lower left` which is the same as `center_origin=True`