### PR TITLE
Docs: Remove <p> from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<p align="center"><picture>
+<picture>
 <img width="110%" height="110%" src="./docs/source/_static/logo.svg" alt="pymovements">
-</picture></p>
+</picture>
 
 ---
 


### PR DESCRIPTION
The <p> tag isn't needed anymore as the <picture> tag already does the centering