### PR TITLE
CI: Disable three pylint checks for tests directory.

### DIFF
--- a/tests/events/test_events_base.py
+++ b/tests/events/test_events_base.py
@@ -8,7 +8,6 @@ from pymovements.events import Fixation
 from pymovements.events import Saccade
 
 
-# pylint: disable=protected-access
 @pytest.mark.parametrize(
     'event_class, init_params, expected',
     [

--- a/tests/synthetic/test_step_function.py
+++ b/tests/synthetic/test_step_function.py
@@ -78,8 +78,6 @@ from pymovements.synthetic import step_function
     ],
 )
 def test_step_function(params, expected):
-    """Test step function."""
-
     if 'exception' in expected:
         with pytest.raises(expected['exception']):
             step_function(**params)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,7 +1,6 @@
 """
 Test all functions in pymovements.transforms.
 """
-# pylint: disable=missing-function-docstring
 import numpy as np
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,9 @@ deps =
     pytest
 changedir = {toxinidir}
 commands =
-    pylint --rcfile=pylintrc --output-format=parseable {toxinidir}/src/pymovements {toxinidir}/tests
+    pylint --rcfile=pylintrc --output-format=parseable {toxinidir}/src/pymovements
+    pylint --rcfile=pylintrc --output-format=parseable \
+    --disable=missing-class-docstring,missing-function-docstring,protected-access {toxinidir}/tests
 
 
 [testenv:pre-commit]


### PR DESCRIPTION
Some of the cases are just not necessary for tests. This disables:
- missing-class-docstring
- missing-function-docstring
- protected-access