### PR TITLE
CI: remove flake8 args from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,66 +8,27 @@ repos:
     rev: v3.3.1
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
+        args: [--py36-plus]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v3.9.0
     hooks:
     -   id: reorder-python-imports
         args: [--application-directories=src]
--   repo: https://github.com/dannysepler/rm_unneeded_f_str
-    rev: v0.2.0
-    hooks:
-    -   id: rm-unneeded-f-str
--   repo: https://github.com/pappasam/toml-sort
-    rev: v0.22.3
-    hooks:
-    -   id: toml-sort-fix
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: check-builtin-literals
-    -   id: check-case-conflict
     -   id: check-docstring-first
-    -   id: check-merge-conflict
-    -   id: check-toml
-    -   id: check-xml
     -   id: check-yaml
     -   id: debug-statements
-    -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
-    -   id: no-commit-to-branch
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.9.0
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.0
-    hooks:
-    -   id: autopep8
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-all]
--   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-    -   id: python-check-blanket-noqa
-    -   id: python-check-blanket-type-ignore
--   repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.1
-    hooks:
-    -   id: autoflake
--   repo: https://github.com/PyCQA/docformatter
-    rev: v1.6.0-rc2
-    hooks:
-    -   id: docformatter
--   repo: https://github.com/PyCQA/doc8
-    rev: v1.1.1
-    hooks:
-    -   id: doc8
 -   repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
     -   id: flake8
-        args: ['--max-line-length=100']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,73 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-    -   id: check-docstring-first
-    -   id: check-yaml
-    -   id: debug-statements
-    -   id: end-of-file-fixer
-    -   id: requirements-txt-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.9.0
-    hooks:
-    -   id: reorder-python-imports
-        args: [--application-directories=src]
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-    -   id: pyupgrade
-        args: [--py36-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.4.0
     hooks:
     -   id: add-trailing-comma
         args: [--py36-plus]
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
     hooks:
-    -   id: flake8
-        args: ['--max-line-length=100']
+    -   id: pyupgrade
+        args: [--py37-plus]
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.9.0
+    hooks:
+    -   id: reorder-python-imports
+        args: [--application-directories=src]
+-   repo: https://github.com/dannysepler/rm_unneeded_f_str
+    rev: v0.2.0
+    hooks:
+    -   id: rm-unneeded-f-str
+-   repo: https://github.com/pappasam/toml-sort
+    rev: v0.22.3
+    hooks:
+    -   id: toml-sort-fix
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: check-builtin-literals
+    -   id: check-case-conflict
+    -   id: check-docstring-first
+    -   id: check-merge-conflict
+    -   id: check-toml
+    -   id: check-xml
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: double-quote-string-fixer
+    -   id: end-of-file-fixer
+    -   id: no-commit-to-branch
+    -   id: requirements-txt-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.9.0
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v2.0.0
+    hooks:
+    -   id: autopep8
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-all]
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+    -   id: python-check-blanket-noqa
+    -   id: python-check-blanket-type-ignore
+-   repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.1
+    hooks:
+    -   id: autoflake
+-   repo: https://github.com/PyCQA/docformatter
+    rev: v1.6.0-rc2
+    hooks:
+    -   id: docformatter
+-   repo: https://github.com/PyCQA/doc8
+    rev: v1.1.1
+    hooks:
+    -   id: doc8
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+        args: ['--max-line-length=100']


### PR DESCRIPTION
specifying flake8 args is not necessary here, as flake automatically parses tox.ini if present