### PR TITLE
CI: Move mypy definitions to pyproject.toml

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,0 @@
-[mypy]
-exclude = src/pymovements/plot.py
-
-[mypy-scipy.*]
-ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,14 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.autopep8]
+max_line_length = 100
+in-place = true
+recursive = true
+aggressive = 1
+
+[tool.doc8]
+max-line-length = 100
 
 [tool.mypy]
 exclude = ['src/pymovements/plot.py']
@@ -12,13 +20,3 @@ exclude = ['src/pymovements/plot.py']
 [[tool.mypy.overrides]]
 module = "scipy.*"
 ignore_missing_imports = true
-
-[tool.autopep8]
-max_line_length = 100
-in-place = true
-recursive = true
-aggressive = 1
-
-
-[tool.doc8]
-max-line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 
+[tool.mypy]
+exclude = ['src/pymovements/plot.py']
+
+[[tool.mypy.overrides]]
+module = "scipy.*"
+ignore_missing_imports = true
+
 [tool.autopep8]
 max_line_length = 100
 in-place = true


### PR DESCRIPTION
Currently our root directory is a bit cluttered with configuration files.

I made a start in resolving this issue by moving the few definitions in the `mypy.ini` to the `pyproject.toml`.

The definitions from `setup.cfg`, `tox.ini` and `pylintrc` will be migrated in some future sprints.
pre-commit and readthedocs unfortunately are stubborn and not willing to support `pyproject.toml`.