### PR TITLE
CI: Add pre-commit to GitHub workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
           - flake8
           - pylint
           - mypy
+          - pre-commit
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,11 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-
 [tool.autopep8]
 max_line_length = 100
 in-place = true
 recursive = true
 aggressive = 1
-
 
 [tool.doc8]
 max-line-length = 100


### PR DESCRIPTION
I added pre-commit to the GitHub workflows.
I'm not sure if it makes sense in addition to the pre-commit.ci?

Also, this way flake8 and mypy will be run two times.
Maybe exclude it here by using `stages`? This could also be a reasonable setup for the pre-commit ci.