### PR TITLE
CI: Add configuration for pre-commit-ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,15 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.ci hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: [flake8, mypy]
+    submodules: false
+
 repos:
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,11 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-
 [tool.autopep8]
 max_line_length = 100
 in-place = true
 recursive = true
 aggressive = 1
-
 
 [tool.doc8]
 max-line-length = 100


### PR DESCRIPTION
regarding the issue stated in PR #134 

pre-commit-ci now won't run flake8 and mypy as this is already handled in a separate job by GitHub workflows.