### PR TITLE
Git: Ignore coverage.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ docs/source/reference/pymovements.*.rst
 .tox
 .coverage
 .coverage.*
+coverage.xml
 htmlcov/


### PR DESCRIPTION
We generate an additional coverage file to be uploaded to codecov on every workflow run. Ignore it for commits.