### PR TITLE
Docs: Fix logo url and centering for both pypi and local usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-<picture>
-<img width="110%" height="110%" src="./docs/source/_static/logo.svg" alt="pymovements">
-</picture>
+<p style="text-align:center;">
+<img width="110%" height="110%" alt="pymovements"
+ src="https://raw.githubusercontent.com/aeye-lab/pymovements/main/docs/source/_static/logo.svg"
+ onerror="this.onerror=null;this.src='./docs/source/_static/logo.svg';"/>
+</p>
 
 ---
 


### PR DESCRIPTION
PyPi does not support relative urls to images (PyPi doesn't store these resources after all).
Moreover, PyPi does not support the `<center>` tag.

I fixed this manually for the last releases before building the packages, but if I forget it, I have to create a new release as PyPi does not allow for changing published releases.

I still want to support the use case where you are offline and want to go through the readme and see the nice logo.

So now per default the github resource is shown, and if that fails the relative url is chosen. If that fails again pymovements is just written at the top.

I think that's the best compromise there is to support both environments.