### PR TITLE
CI: Move pytest config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,9 @@ exclude = ['src/pymovements/plot.py']
 [[tool.mypy.overrides]]
 module = "scipy.*"
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "-ra -l -v --doctest-modules"
+doctest_optionflags = "NORMALIZE_WHITESPACE"
+filterwarnings = ['ignore::DeprecationWarning:pkg_resources.*:']
+testpaths = ['tests', 'src']

--- a/tox.ini
+++ b/tox.ini
@@ -96,15 +96,6 @@ exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
 max-line-length = 100
 
 
-[pytest]
-testpaths =
-    tests
-    src
-addopts = -ra -l -v --doctest-modules
-filterwarnings =
-    ignore::DeprecationWarning:pkg_resources.*:
-
-
 [coverage:run]
 parallel = True
 branch = True


### PR DESCRIPTION
This additionally adds the `NORMALIZE_WHITESPACE` option as default for running doctests