### PR TITLE
Transforms: Fix padding bug in cut_into_subsequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-<picture>
-<img width="110%" height="110%" src="./docs/source/_static/logo.svg" alt="pymovements">
-</picture>
+<p style="text-align:center;">
+<img width="110%" height="110%" alt="pymovements"
+ src="https://raw.githubusercontent.com/aeye-lab/pymovements/main/docs/source/_static/logo.svg"
+ onerror="this.onerror=null;this.src='./docs/source/_static/logo.svg';"/>
+</p>
 
 ---
 

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -285,22 +285,22 @@ def cut_into_subsequences(
     idx = 0
     for t in range(0, arr.shape[0]):
         for i in range(0, n):
-            # get piece of respective sequence
+            # get part of the sequence with window_size
             arr_tmp = np.expand_dims(arr[t, i * window_size: (i + 1) * window_size, :], axis=0)
 
-            # fill respective instance with piece
+            # fill row with respective part of the sequence
             arr_cut[idx, :, :] = arr_tmp
 
             idx = idx + 1
 
         if rest > 0 and keep_padded:
-            # concatenate last one with pad
+            # get end point of last part of the sequence
             start_idx_last_piece = window_size * n
 
-            # piece to pad
+            # get last part of sequence which is shorter than window_size
             arr_incomplete = arr[t, start_idx_last_piece:, :]
 
-            # insert last piece, remaining samples are already np.nan
+            # insert last part, remaining samples are already np.nan
             arr_cut[idx, :rest, :] = arr_incomplete
 
             idx = idx + 1

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -256,24 +256,22 @@ def norm(arr: np.ndarray, axis: int | None = None) -> np.ndarray | Any:
 def cut_into_subsequences(
     arr: np.ndarray, window_size: int, keep_padded: bool = True,
 ) -> np.ndarray:
-    """
-    Example: if old seq len was 7700, window_size=1000:
-    Input arr has: 144 x 7700 x n_channels
-    Output arr has: 144*8 x 1000 x n_channels
-    The last piece of each trial 7000-7700 gets padded with first 300 of this piece to be 1000 long
+    """Cut sequence into subsequences of equal length.
 
     Parameters
     ----------
     arr: np.ndarray
-        uncut sequence
+        Input sequence of shape (N, L, C).
     window_size: int
         size of subsequences
     keep_padded: bool
-        If True, last subsequence (which is padded) is kept in the output array.
+        If True, last subsequence (if not of length `window_size`) is kept in the output array and
+        padded with np.nan.
 
     Returns
     -------
     np.ndarray
+        Output sequence with new window length of shape (N', L', C)
     """
     n, rest = np.divmod(arr.shape[1], window_size)
 
@@ -287,10 +285,10 @@ def cut_into_subsequences(
     idx = 0
     for t in range(0, arr.shape[0]):
         for i in range(0, n):
-            # cut out 1000 ms piece of trial t
+            # get piece of respective sequence
             arr_tmp = np.expand_dims(arr[t, i * window_size: (i + 1) * window_size, :], axis=0)
 
-            # concatenate pieces
+            # fill respective instance with piece
             arr_cut[idx, :, :] = arr_tmp
 
             idx = idx + 1
@@ -298,19 +296,12 @@ def cut_into_subsequences(
         if rest > 0 and keep_padded:
             # concatenate last one with pad
             start_idx_last_piece = window_size * n
-            len_pad_to_add = window_size - rest
-            # piece to pad:
-            arr_incomplete = np.expand_dims(arr[t, start_idx_last_piece:arr.shape[1], :], axis=0)
-            # padding piece:
-            start_idx_last_piece = window_size * (n - 1)
-            arr_pad = np.expand_dims(
-                arr[t, start_idx_last_piece:start_idx_last_piece + len_pad_to_add, :], axis=0,
-            )
 
-            arr_tmp = np.concatenate((arr_incomplete, arr_pad), axis=1)
+            # piece to pad
+            arr_incomplete = arr[t, start_idx_last_piece:, :]
 
-            # concatenate last piece of original row t
-            arr_cut[idx, :, :] = arr_tmp
+            # insert last piece, remaining samples are already np.nan
+            arr_cut[idx, :rest, :] = arr_incomplete
 
             idx = idx + 1
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -6,6 +6,8 @@ import pytest
 
 from pymovements.transforms import pix2deg
 from pymovements.transforms import pos2vel
+from pymovements.transforms import cut_into_subsequences
+
 
 n_coords = 100
 screen_px_1d = 100
@@ -485,3 +487,44 @@ def test_pos2vel_stepped_input_returns(params, expected_value):
 
     lpad, rpad = 1, -1
     assert np.allclose(actual_value[lpad:rpad], expected_value[lpad:rpad])
+
+
+@pytest.mark.parametrize(
+    'params, expected',
+    [
+        pytest.param(
+            {'arr': np.ones((1, 10, 2)), 'window_size': 5, 'keep_padded': False},
+            {'value': np.ones((2, 5, 2))},
+            id='length_double_window_size_keep_padded_returns_two_instances',
+        ),
+        pytest.param(
+            {'arr': np.ones((1, 10, 2)), 'window_size': 5, 'keep_padded': True},
+            {'value': np.ones((2, 5, 2))},
+            id='length_double_window_size_not_keep_padded_returns_two_instances',
+        ),
+        pytest.param(
+            {'arr': np.ones((1, 11, 2)), 'window_size': 5, 'keep_padded': False},
+            {'value': np.ones((2, 5, 2))},
+            id='length_double_window_size+1_keep_padded_returns_two_instances',
+        ),
+        pytest.param(
+            {'arr': np.ones((1, 11, 2)), 'window_size': 5, 'keep_padded': True},
+            {'value': np.concatenate([
+                np.ones((2, 5, 2)),
+                np.expand_dims(np.concatenate([np.ones((1, 2)), np.ones((4,2))*np.nan]), 0),
+            ])},
+            id='length_double_window_size+1_not_keep_padded_returns_three_instances',
+        ),
+    ],
+)
+def test_cut_into_subsequences(params, expected):
+    if 'exception' in expected:
+        with pytest.raises(expected['exception']):
+            cut_into_subsequences(**params)
+        return
+
+    arr = cut_into_subsequences(**params)
+
+    assert np.array_equal(arr, expected['value'], equal_nan=True), (
+        f"arr = {arr}, expected = {expected['value']}"
+    )


### PR DESCRIPTION
Thanks to the examples in #95 from @theDebbister we could find a bug for the padding in `cut_into_subsequences()`.

Fortunately I never used `keep_padded=True`, but I have added the respective tests to prevent regressions.