### PR TITLE
Events: Return dataframe in detection methods.

### DIFF
--- a/src/pymovements/events/engbert.py
+++ b/src/pymovements/events/engbert.py
@@ -92,8 +92,8 @@ def microsaccades(
     event_df = pl.from_dict(
         {
             'type': 'saccade',
-            'onset': saccades[:, 0],
-            'offset': saccades[:, 1],
+            'onset': saccades[:, 0].tolist(),
+            'offset': saccades[:, 1].tolist(),
         },
     )
     return event_df

--- a/src/pymovements/events/ivt.py
+++ b/src/pymovements/events/ivt.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-from pymovements.transforms import norm
 from pymovements.transforms import consecutive
+from pymovements.transforms import norm
 
 
 def ivt(

--- a/src/pymovements/events/ivt.py
+++ b/src/pymovements/events/ivt.py
@@ -102,14 +102,14 @@ def ivt(
 
     # Calculate centroid positions for fixations.
     centroids = [
-        np.mean(positions[fixation[0]:fixation[1]], axis=0, dtype=np.float64)
+        np.mean(positions[fixation[0]:fixation[1]], axis=0, dtype=np.float64).tolist()
         for fixation in fixations
     ]
 
     event_df = pl.from_dict({
         'type': 'fixation',
-        'onset': fixations[:, 0],
-        'offset': fixations[:, 1],
+        'onset': fixations[:, 0].tolist(),
+        'offset': fixations[:, 1].tolist(),
         'position': centroids,
     })
     return event_df

--- a/src/pymovements/events/ivt.py
+++ b/src/pymovements/events/ivt.py
@@ -4,16 +4,18 @@ This module holds the implementation of the ivt algorithm.
 from __future__ import annotations
 
 import numpy as np
+import polars as pl
 
-from pymovements.events import Fixation
 from pymovements.transforms import norm
+from pymovements.transforms import consecutive
 
 
 def ivt(
         positions: list[list[float]] | np.ndarray,
         velocities: list[list[float]] | np.ndarray,
         velocity_threshold: float,
-) -> list[Fixation]:
+        minimum_duration: int,
+) -> pl.DataFrame:
     """
     Identification of fixations based on velocity-threshold
 
@@ -33,11 +35,13 @@ def ivt(
     velocity_threshold: float
         Threshold for a point to be classified as a fixation. If the
         velocity is below the threshold, the point is classified as a fixation.
+    minimum_duration: int
+        Minimum fixation duration in number of samples
 
     Returns
     -------
-    list[Fixation]:
-        List of Fixation events
+    pl.DataFrame
+        A dataframe with detected fixations as rows.
 
     Raises
     ------
@@ -81,30 +85,31 @@ def ivt(
 
     velocity_norm = norm(velocities, axis=1)
 
-    # Map velocities lower than threshold to True and greater equals to False
-    fix_map = velocity_norm < velocity_threshold
+    # Get all indices with velocities outside of ellipse.
+    below_threshold_indices = np.where(velocity_norm < velocity_threshold)[0]
 
-    # Find onsets for group of velocities
-    loc_group_onsets = np.empty(len(positions), dtype=bool)
-    loc_group_onsets[0] = True
-    np.not_equal(fix_map[:-1], fix_map[1:], out=loc_group_onsets[1:])
-    ind_group_onsets = np.nonzero(loc_group_onsets)[0]
+    # Get all fixation candidates by grouping all consecutive indices.
+    candidates = consecutive(arr=below_threshold_indices)
 
-    # Find offsets for group of velocities
-    group_lengths = np.diff(np.append(ind_group_onsets, len(positions)))
-    ind_group_offsets = np.add(ind_group_onsets, group_lengths)
+    # Filter all candidates by minimum duration.
+    candidates = [candidate for candidate in candidates if len(candidate) >= minimum_duration]
 
-    # Stack onsets and offsets and filter out fixation groups
-    groups = np.stack((ind_group_onsets, ind_group_offsets), axis=1)
-    fix_groups = groups[[fix_map[group[0]] == 1 for group in groups]]
+    # Create ficaitons from valid candidates. First channel is onset, second channel is offset.
+    fixations = np.array([
+        (candidate_indices[0], candidate_indices[-1])
+        for candidate_indices in candidates
+    ])
 
-    fixations = []
+    # Calculate centroid positions for fixations.
+    centroids = [
+        np.mean(positions[fixation[0]:fixation[1]], axis=0, dtype=np.float64)
+        for fixation in fixations
+    ]
 
-    for onset, offset in fix_groups:
-        fixation_points = positions[onset:offset]
-        centroid = np.mean(fixation_points, axis=0, dtype=np.float64)
-        centroid = (centroid[0], centroid[1])
-
-        fixations.append(Fixation(onset, offset, centroid))
-
-    return fixations
+    event_df = pl.from_dict({
+        'type': 'fixation',
+        'onset': fixations[:, 0],
+        'offset': fixations[:, 1],
+        'position': centroids,
+    })
+    return event_df

--- a/tests/events/test_idt.py
+++ b/tests/events/test_idt.py
@@ -1,10 +1,10 @@
-"""
-This module tests functionality of the IDT algorithm
-
-"""
+"""This module tests functionality of the IDT algorithm."""
+import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 
 from pymovements.events.idt import idt
+from pymovements.synthetic import step_function
 
 
 @pytest.mark.parametrize(
@@ -14,7 +14,7 @@ from pymovements.events.idt import idt
             {
                 'positions': None,
                 'dispersion_threshold': 1,
-                'duration_threshold': 1,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_none_raises_value_error',
@@ -23,7 +23,7 @@ from pymovements.events.idt import idt
             {
                 'positions': [[1, 2], [1, 2]],
                 'dispersion_threshold': None,
-                'duration_threshold': 1,
+                'minimum_duration': 1,
             },
             TypeError,
             id='dispersion_threshold_none_raises_type_error',
@@ -32,7 +32,7 @@ from pymovements.events.idt import idt
             {
                 'positions': [[1, 2], [1, 2]],
                 'dispersion_threshold': 1,
-                'duration_threshold': None,
+                'minimum_duration': None,
             },
             TypeError,
             id='duration_threshold_none_raises_type_error',
@@ -41,7 +41,7 @@ from pymovements.events.idt import idt
             {
                 'positions': 1,
                 'dispersion_threshold': 1,
-                'duration_threshold': 1,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_not_array_like_raises_value_error',
@@ -50,7 +50,7 @@ from pymovements.events.idt import idt
             {
                 'positions': [1, 2, 3],
                 'dispersion_threshold': 1,
-                'duration_threshold': 1,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_1d_raises_value_error',
@@ -59,7 +59,7 @@ from pymovements.events.idt import idt
             {
                 'positions': [[1, 2, 3], [1, 2, 3]],
                 'dispersion_threshold': 1,
-                'duration_threshold': 1,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_not_2_elements_in_second_dimension_raises_value_error',
@@ -68,7 +68,7 @@ from pymovements.events.idt import idt
             {
                 'positions': [[1, 2], [1, 2]],
                 'dispersion_threshold': 0,
-                'duration_threshold': 1,
+                'minimum_duration': 1,
             },
             ValueError,
             id='dispersion_threshold_not_greater_than_0_raises_value_error',
@@ -77,7 +77,7 @@ from pymovements.events.idt import idt
             {
                 'positions': [[1, 2], [1, 2]],
                 'dispersion_threshold': 1,
-                'duration_threshold': 0,
+                'minimum_duration': 0,
             },
             ValueError,
             id='duration_threshold_not_greater_than_0_raises_value_error',
@@ -86,7 +86,7 @@ from pymovements.events.idt import idt
             {
                 'positions': [[1, 2], [1, 2]],
                 'dispersion_threshold': 1,
-                'duration_threshold': 1.0,
+                'minimum_duration': 1.0,
             },
             TypeError,
             id='duration_threshold_not_integer_raises_type_error',
@@ -97,3 +97,51 @@ def test_idt_raises_error(kwargs, expected_error):
     """Test if idt raises expected error."""
     with pytest.raises(expected_error):
         idt(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected',
+    [
+        pytest.param(
+            {
+                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
+                'dispersion_threshold': 1,
+                'minimum_duration': 1,
+            },
+            pl.DataFrame(
+                {
+                    'type': ['fixation'],
+                    'onset': [0],
+                    'offset': [99],
+                    'position': [(0.0, 0.0)],
+                },
+            ),
+            id='constant_position_single_fixation',
+        ),
+        pytest.param(
+            {
+                'positions': step_function(
+                    length=100,
+                    steps=[49, 50],
+                    values=[(9, 9), (1, 1)],
+                    start_value=(0, 0),
+                ),
+                'dispersion_threshold': 1,
+                'minimum_duration': 1,
+            },
+            pl.DataFrame(
+                {
+                    'type': 'fixation',
+                    'onset': [0, 50],
+                    'offset': [50, 99],  # should be [49, 99]
+                    'position': [(0.18, 0.18), (1.0, 1.0)],  # should be: [(0.0, 0.0), (1.0, 1.0)]
+                },
+            ),
+            id='three_steps_two_fixations',
+        ),
+    ],
+)
+def test_idt_detects_fixations(kwargs, expected):
+    events = idt(**kwargs)
+
+    assert_frame_equal(events, expected)

--- a/tests/events/test_ivt.py
+++ b/tests/events/test_ivt.py
@@ -1,12 +1,12 @@
-"""
-This module tests functionality of base event classes.
-"""
-from __future__ import annotations
-
+"""This module tests functionality of the IVT algorithm."""
 import numpy as np
+import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 
 from pymovements.events.ivt import ivt
+from pymovements.synthetic import step_function
+from pymovements.transforms import pos2vel
 
 
 @pytest.mark.parametrize(
@@ -17,6 +17,7 @@ from pymovements.events.ivt import ivt
                 'positions': None,
                 'velocities': np.ones((100, 2)),
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_none_raises_value_error',
@@ -26,6 +27,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': None,
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='velocities_none_raises_value_error',
@@ -35,6 +37,7 @@ from pymovements.events.ivt import ivt
                 'positions': 1,
                 'velocities': np.ones((100, 2)),
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_not_array_like_raises_value_error',
@@ -44,6 +47,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': 1,
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='velocities_not_array_like_raises_value_error',
@@ -53,6 +57,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones(100),
                 'velocities': np.ones((100, 2)),
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_not_2d_array_raises_value_error',
@@ -62,6 +67,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': np.ones(100),
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='velocities_not_2d_array_raises_value_error',
@@ -71,6 +77,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 3)),
                 'velocities': np.ones((100, 2)),
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_not_2_elements_in_second_dimension_raises_value_error',
@@ -80,6 +87,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': np.ones((100, 3)),
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='velocities_not_2_elements_in_second_dimension_raises_value_error',
@@ -89,6 +97,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': np.ones((101, 2)),
                 'velocity_threshold': 1.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='positions_and_velocities_different_lengths_raises_value_error',
@@ -98,6 +107,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': np.ones((100, 2)),
                 'velocity_threshold': None,
+                'minimum_duration': 1,
             },
             ValueError,
             id='velocity_threshold_none_raises_value_error',
@@ -107,6 +117,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': np.ones((100, 2)),
                 'velocity_threshold': '1.',
+                'minimum_duration': 1,
             },
             TypeError,
             id='velocity_threshold_not_float_raises_type_error',
@@ -116,6 +127,7 @@ from pymovements.events.ivt import ivt
                 'positions': np.ones((100, 2)),
                 'velocities': np.ones((100, 2)),
                 'velocity_threshold': 0.,
+                'minimum_duration': 1,
             },
             ValueError,
             id='velocity_threshold_not_greater_than_0_raises_value_error',
@@ -126,3 +138,52 @@ def test_ivt_raise_error(kwargs, expected_error):
     """Test if ivt raises expected error."""
     with pytest.raises(expected_error):
         ivt(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected',
+    [
+        pytest.param(
+            {
+                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
+                'velocity_threshold': 1,
+                'minimum_duration': 1,
+            },
+            pl.DataFrame(
+                {
+                    'type': 'fixation',
+                    'onset': [0],
+                    'offset': [99],
+                    'position': [(0.0, 0.0)],
+                },
+            ),
+            id='constant_position_single_fixation',
+        ),
+        pytest.param(
+            {
+                'positions': step_function(
+                    length=100,
+                    steps=[49, 50],
+                    values=[(9, 9), (1, 1)],
+                    start_value=(0, 0),
+                ),
+                'velocity_threshold': 1,
+                'minimum_duration': 1,
+            },
+            pl.DataFrame(
+                {
+                    'type': 'fixation',
+                    'onset': [0, 51],
+                    'offset': [48, 99],
+                    'position': [(0.0, 0.0), (1.0, 1.0)],
+                },
+            ),
+            id='three_steps_two_fixations',
+        ),
+    ],
+)
+def test_idt_detects_fixations(kwargs, expected):
+    velocities = pos2vel(kwargs['positions'], sampling_rate=10, method='preceding')
+    events = ivt(velocities=velocities, **kwargs)
+
+    assert_frame_equal(events, expected)


### PR DESCRIPTION
## Description
In the version before a list of Event objects was returned, which would be very inefficient to process.
I did this originally because I had to focus on other things at it seemed to be the most trivial way.

Now as I got a bit more experience with polars I changed this and we now have nice polars DataFrames as an output.
What I'm not sure about, should we now just delete these Event classes?

Fixes issue #65

## Implemented changes

- [x] Return DataFrame in `events.engbert.microsaccades()`
- [x] Return DataFrame in `events.idt.idt()`
- [x] Return DataFrame in `events.ivt.ivt()`
- [x] Refactor `events.idt.idt()` such that `transforms.consecutive()` is being used


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is or requires a documentation update

## How Has This Been Tested?

I have tested this by using the step function.

- [x] IDT/IVT: 
  - [x] constant position sequence -> single fixation
  - [x] three steps (one short in the middle) -> two fixations
- [x] microsaccades:
  - [x] two steps -> one saccade
  - [x] four steps -> two saccades

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
