### PR TITLE
Modules: Provide top-level imports via init files

### DIFF
--- a/src/pymovements/__init__.py
+++ b/src/pymovements/__init__.py
@@ -1,0 +1,5 @@
+"""This module provides access to all submodules."""
+from pymovements import datasets  # noqa: F401
+from pymovements import events  # noqa: F401
+from pymovements import synthetic  # noqa: F401
+from pymovements import utils  # noqa: F401

--- a/src/pymovements/events/__init__.py
+++ b/src/pymovements/events/__init__.py
@@ -4,3 +4,6 @@ This module holds all event related functionality.
 from pymovements.events.base import Event  # noqa: F401
 from pymovements.events.base import Fixation  # noqa: F401
 from pymovements.events.base import Saccade  # noqa: F401
+from pymovements.events.engbert import microsaccades  # noqa: F401
+from pymovements.events.idt import idt  # noqa: F401
+from pymovements.events.ivt import ivt  # noqa: F401

--- a/src/pymovements/utils/__init__.py
+++ b/src/pymovements/utils/__init__.py
@@ -1,0 +1,6 @@
+"""This module provides access to all utility functions."""
+from pymovements.utils import archives  # noqa: F401
+from pymovements.utils import checks  # noqa: F401
+from pymovements.utils import decorators  # noqa: F401
+from pymovements.utils import downloads  # noqa: F401
+from pymovements.utils import paths  # noqa: F401


### PR DESCRIPTION
## Description

Add top level imports to all init files.
This way using the package is much more comfortable.

Before this raised an error:
```
import pymovements as pm
pm.events.ivt()

Traceback (most recent call last):
  File "pymovements/venv/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3378, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-e589eee00459>", line 1, in <module>
    pm.events.ivt()
AttributeError: module 'pymovements' has no attribute 'events'
```

Now it works as expected.

## Implemented changes

- [x] Add top level imports to `pymovements.__init__.py`
- [x] Add top level imports to `pymovements.events.__init__.py`
- [x] Add top level imports to `pymovements.utils.__init__.py`

`pymovements.datasets` was already in correct shape.
It's not needed yet for `pymovements.plots` and `pymovements.transforms` as these are single files.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
