### PR TITLE
Docs: Add badge for number of lines of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Test Status](https://img.shields.io/github/actions/workflow/status/aeye-lab/pymovements/tests.yml?label=tests)](https://github.com/aeye-lab/pymovements/actions/workflows/tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/pymovements/badge/?version=latest)](https://pymovements.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/github/aeye-lab/pymovements/branch/main/graph/badge.svg?token=QY3NDHAT2C)](https://codecov.io/github/aeye-lab/pymovements)
+[![lines of code](https://tokei.rs/b1/github/aeye-lab/pymovements?category=code)](https://github.com/aeye-lab/pymovements)
 [![PyPI downloads/month](https://img.shields.io/pypi/dm/pymovements.svg)](https://pypistats.org/packages/pymovements)
 
 


### PR DESCRIPTION
looks like this: [![lines of code](https://tokei.rs/b1/github/aeye-lab/pymovements?category=code)](https://github.com/aeye-lab/pymovements)

provided by: https://github.com/XAMPPRocky/tokei_rs

Also provided:

 [![total lines](https://tokei.rs/b1/github/aeye-lab/pymovements?category=lines)](https://github.com/aeye-lab/pymovements)

 [![blank lines](https://tokei.rs/b1/github/aeye-lab/pymovements?category=blanks)](https://github.com/aeye-lab/pymovements)

 [![files](https://tokei.rs/b1/github/aeye-lab/pymovements?category=files)](https://github.com/aeye-lab/pymovements)

 [![comments](https://tokei.rs/b1/github/aeye-lab/pymovements?category=comments)](https://github.com/aeye-lab/pymovements)