### PR TITLE
Datasets: Add examples to GazeBase and JuDo1000

### DIFF
--- a/src/pymovements/datasets/__init__.py
+++ b/src/pymovements/datasets/__init__.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """This module provides access to publicly available datasets."""
-from pymovements.datasets.base import Dataset  # noqa: F401
-from pymovements.datasets.base import PublicDataset  # noqa: F401
+from pymovements.datasets.dataset import Dataset  # noqa: F401
 from pymovements.datasets.gazebase import GazeBase  # noqa: F401
 from pymovements.datasets.judo1000 import JuDo1000  # noqa: F401
+from pymovements.datasets.public_dataset import PublicDataset  # noqa: F401

--- a/src/pymovements/datasets/dataset.py
+++ b/src/pymovements/datasets/dataset.py
@@ -17,21 +17,17 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""This module provides base dataset classes."""
+"""This module provides the base dataset class."""
 from __future__ import annotations
 
 import re
-from abc import ABCMeta
-from abc import abstractmethod
 from pathlib import Path
 from typing import Any
-from urllib.error import URLError
 
 import polars as pl
 from tqdm.auto import tqdm
 
 from pymovements.base import Experiment
-from pymovements.utils.downloads import download_and_extract_archive
 from pymovements.utils.paths import get_filepaths
 
 
@@ -307,91 +303,3 @@ class Dataset:
         Path('data/CustomDataset/raw')
         """
         return self.dirpath / 'raw'
-
-
-class PublicDataset(Dataset, metaclass=ABCMeta):
-    """Extends the `Dataset` abstract base class with functionality for downloading in extracting.
-
-    To implement this abstract base class for a new dataset, the attributes/properties `_mirrors`
-    and `_resources` must be implemented.
-    """
-
-    def __init__(
-        self,
-        root: str,
-        download: bool = False,
-        remove_finished: bool = False,
-        **kwargs,
-    ):
-        super().__init__(root=root, **kwargs)
-        if download:
-            self.download(remove_finished=remove_finished)
-
-    def download(self, remove_finished: bool = False) -> None:
-        """Download dataset.
-
-        Parameters
-        ----------
-        remove_finished : bool
-            Remove archive files after extraction.
-
-        Raises
-        ------
-        RuntimeError
-            If downloading a resource failed for all given mirrors.
-        """
-        self.raw_dirpath.mkdir(parents=True, exist_ok=True)
-
-        for resource in self._resources:
-            success = False
-
-            for mirror in self._mirrors:
-
-                url = f'{mirror}{resource["resource"]}'
-
-                try:
-                    download_and_extract_archive(
-                        url=url,
-                        download_dirpath=self.dirpath,
-                        download_filename=resource['filename'],
-                        extract_dirpath=self.raw_dirpath,
-                        md5=resource['md5'],
-                        recursive=True,
-                        remove_finished=remove_finished,
-                    )
-                    success = True
-
-                except URLError as error:
-                    print(f'Failed to download (trying next):\n{error}')
-                    # downloading the resource, try next mirror
-                    continue
-
-                # downloading the resource was successful, we don't need to try another mirror
-                break
-
-            if not success:
-                raise RuntimeError(
-                    f"downloading resource {resource['resource']} failed for all mirrors.",
-                )
-
-    @property
-    @abstractmethod
-    def _mirrors(self):
-        """This attribute/property must provide a list of mirrors of the dataset.
-
-        Each entry should be of type `str` and end with a '/'.
-        """
-
-    @property
-    @abstractmethod
-    def _resources(self):
-        """This attribute must provide a list of dataset resources.
-
-        Each list entry should be a dictionary with the following keys:
-
-        - resource: The url suffix of the resource. This will be concatenated with the mirror.
-        - filename: The filename under which the file is saved as.
-        - md5: The MD5 checksum of the respective file.
-
-        All values should be of type string.
-        """

--- a/src/pymovements/datasets/dataset.py
+++ b/src/pymovements/datasets/dataset.py
@@ -107,7 +107,7 @@ class Dataset:
 
         # Get all filepaths that match regular expression.
         csv_filepaths = get_filepaths(
-            path=self.raw_dirpath,
+            path=self.raw_rootpath,
             regex=filename_regex,
         )
 
@@ -272,7 +272,7 @@ class Dataset:
                 )
 
     @property
-    def dirpath(self) -> Path:
+    def rootpath(self) -> Path:
         """Get the path to the dataset directory.
 
         The dataset path points to a directory in the specified root directory which is named the
@@ -283,23 +283,23 @@ class Dataset:
         >>> class CustomDataset(Dataset):
         ...     pass
         >>> dataset = CustomDataset(root='data')
-        >>> dataset.dirpath  # doctest: +SKIP
+        >>> dataset.rootpath  # doctest: +SKIP
         Path('data/CustomDataset')
         """
         return self.root / self.__class__.__name__
 
     @property
-    def raw_dirpath(self) -> Path:
+    def raw_rootpath(self) -> Path:
         """Get the path to the directory of the raw data.
 
-        The raw data directory path points to a directory named `raw` in the dataset `dirpath`.
+        The raw data directory path points to a directory named `raw` in the dataset `rootpath`.
 
         Example
         -------
         >>> class CustomDataset(Dataset):
         ...     pass
         >>> dataset = CustomDataset(root='data')
-        >>> dataset.raw_dirpath  # doctest: +SKIP
+        >>> dataset.raw_rootpath  # doctest: +SKIP
         Path('data/CustomDataset/raw')
         """
-        return self.dirpath / 'raw'
+        return self.rootpath / 'raw'

--- a/src/pymovements/datasets/gazebase.py
+++ b/src/pymovements/datasets/gazebase.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 """This module provides an interface to the GazeBase dataset."""
 from pymovements.base import Experiment
-from pymovements.datasets.base import PublicDataset
+from pymovements.datasets.public_dataset import PublicDataset
 
 
 class GazeBase(PublicDataset):

--- a/src/pymovements/datasets/gazebase.py
+++ b/src/pymovements/datasets/gazebase.py
@@ -38,6 +38,16 @@ class GazeBase(PublicDataset):
     task (BLG).
 
     Check the respective paper for details :cite:p:`GazeBase`.
+
+    Change to ``download=True`` and `extract=True`` for downloading and extracting the dataset.
+
+    >>> dataset = GazeBase(
+    ...     root='data/',
+    ...     download=False,
+    ...     extract=False,
+    ...     remove_finished=False,
+    ... )
+    >>> dataset.load()  # doctest: +SKIP
     """
     _mirrors = [
         'https://figshare.com/ndownloader/files/',

--- a/src/pymovements/datasets/judo1000.py
+++ b/src/pymovements/datasets/judo1000.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 """This module provides an interface to the JuDo1000 dataset."""
 from pymovements.base import Experiment
-from pymovements.datasets.base import PublicDataset
+from pymovements.datasets.public_dataset import PublicDataset
 
 
 class JuDo1000(PublicDataset):

--- a/src/pymovements/datasets/judo1000.py
+++ b/src/pymovements/datasets/judo1000.py
@@ -32,6 +32,18 @@ class JuDo1000(PublicDataset):
     screen.
 
     Check the respective `repository <'https://osf.io/download/4wy7s/'>` for details.
+
+    Examples
+    --------
+    Change to ``download=True`` and `extract=True`` for downloading and extracting the dataset.
+
+    >>> dataset = JuDo1000(
+    ...     root='data/',
+    ...     download=False,
+    ...     extract=False,
+    ...     remove_finished=False,
+    ... )
+    >>> dataset.load()  # doctest: +SKIP
     """
     _mirrors = [
         'https://osf.io/download/',

--- a/src/pymovements/datasets/public_dataset.py
+++ b/src/pymovements/datasets/public_dataset.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2023-2023 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""This module provides the abstract base public dataset class."""
+from __future__ import annotations
+
+from abc import ABCMeta
+from abc import abstractmethod
+from urllib.error import URLError
+
+from pymovements.datasets.dataset import Dataset
+from pymovements.utils.downloads import download_and_extract_archive
+
+
+class PublicDataset(Dataset, metaclass=ABCMeta):
+    """Extends the `Dataset` abstract base class with functionality for downloading in extracting.
+
+    To implement this abstract base class for a new dataset, the attributes/properties `_mirrors`
+    and `_resources` must be implemented.
+    """
+
+    def __init__(
+        self,
+        root: str,
+        download: bool = False,
+        remove_finished: bool = False,
+        **kwargs,
+    ):
+        super().__init__(root=root, **kwargs)
+        if download:
+            self.download(remove_finished=remove_finished)
+
+    def download(self, remove_finished: bool = False) -> None:
+        """Download dataset.
+
+        Parameters
+        ----------
+        remove_finished : bool
+            Remove archive files after extraction.
+
+        Raises
+        ------
+        RuntimeError
+            If downloading a resource failed for all given mirrors.
+        """
+        self.raw_dirpath.mkdir(parents=True, exist_ok=True)
+
+        for resource in self._resources:
+            success = False
+
+            for mirror in self._mirrors:
+
+                url = f'{mirror}{resource["resource"]}'
+
+                try:
+                    download_and_extract_archive(
+                        url=url,
+                        download_dirpath=self.dirpath,
+                        download_filename=resource['filename'],
+                        extract_dirpath=self.raw_dirpath,
+                        md5=resource['md5'],
+                        recursive=True,
+                        remove_finished=remove_finished,
+                    )
+                    success = True
+
+                except URLError as error:
+                    print(f'Failed to download (trying next):\n{error}')
+                    # downloading the resource, try next mirror
+                    continue
+
+                # downloading the resource was successful, we don't need to try another mirror
+                break
+
+            if not success:
+                raise RuntimeError(
+                    f"downloading resource {resource['resource']} failed for all mirrors.",
+                )
+
+    @property
+    @abstractmethod
+    def _mirrors(self):
+        """This attribute/property must provide a list of mirrors of the dataset.
+
+        Each entry should be of type `str` and end with a '/'.
+        """
+
+    @property
+    @abstractmethod
+    def _resources(self):
+        """This attribute must provide a list of dataset resources.
+
+        Each list entry should be a dictionary with the following keys:
+
+        - resource: The url suffix of the resource. This will be concatenated with the mirror.
+        - filename: The filename under which the file is saved as.
+        - md5: The MD5 checksum of the respective file.
+
+        All values should be of type string.
+        """

--- a/src/pymovements/datasets/public_dataset.py
+++ b/src/pymovements/datasets/public_dataset.py
@@ -59,7 +59,7 @@ class PublicDataset(Dataset, metaclass=ABCMeta):
         RuntimeError
             If downloading a resource failed for all given mirrors.
         """
-        self.raw_dirpath.mkdir(parents=True, exist_ok=True)
+        self.raw_rootpath.mkdir(parents=True, exist_ok=True)
 
         for resource in self._resources:
             success = False
@@ -71,9 +71,9 @@ class PublicDataset(Dataset, metaclass=ABCMeta):
                 try:
                     download_and_extract_archive(
                         url=url,
-                        download_dirpath=self.dirpath,
+                        download_dirpath=self.rootpath,
                         download_filename=resource['filename'],
-                        extract_dirpath=self.raw_dirpath,
+                        extract_dirpath=self.raw_rootpath,
                         md5=resource['md5'],
                         recursive=True,
                         remove_finished=remove_finished,


### PR DESCRIPTION
This adds a beginner example to GazeBase and JuDo1000.
Both `download` and `extract` are set to false, so no data will be downloaded.

The call to the `load()` method is marked to be skipped for testing.