### PR TITLE
CI: Ignore CSS files for insert-license pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
     -   id: insert-license
         args: [--use-current-year]
-        exclude_types: [bib, image, json, markdown, rst, toml, yaml]
+        exclude_types: [bib, css, image, json, markdown, rst, toml, yaml]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0
     hooks:


### PR DESCRIPTION
Inserting the license with # commentaries will break the CSS syntax so for simplicity we won't put the license into the css stylesheets