### PR TITLE
Docs: Remove How-Tos from sphinx doc

### DIFF
--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -1,9 +1,0 @@
-================
- How-Tos
-================
-
-
-These How-Tos provide detailed information on the usage of specific parts of pymovements.
-
-.. toctree::
-    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,6 @@ Contents
    :maxdepth: 2
 
    getting-started
-   how-to/index
    tutorial/index
    reference/index
    bibliography


### PR DESCRIPTION
I was inspired by another project which has used bot how-tos and tutorials (but no examples in docstrings).

How-tos should be very function specific, tutorials would span a complete scenario (e.g. load data, preprocess it, detect events and create a plot for visual analysis).

I think our how-tos are more or less given in the examples, so I don't see a point anymore in having both how-tos and tutorials.

The tutorials section will soon feature at least one notebook for the typical scenario described above.