### PR TITLE
Docs: Remove table of contents from old style sphinx doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,25 +4,3 @@ Welcome to the pymovements documentation!
 
 .. mdinclude:: ../../README.md
 
-Contents
---------
-
-.. toctree::
-   :maxdepth: 2
-
-   getting-started
-   tutorial/index
-   reference/index
-   bibliography
-
-
-Indices and tables
-------------------
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-
-
-Citing
-------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,3 +4,11 @@ Welcome to the pymovements documentation!
 
 .. mdinclude:: ../../README.md
 
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   getting-started
+   tutorial/index
+   reference/index
+   bibliography


### PR DESCRIPTION
This removes some needless stuff from the index which was inherited from the old styling:

* a table of contents, which is basically useless as it just links to the getting-started, tutorials, api and bibliography. this is already handed in the navigation bar at the top
* some links to indices and module pages, which lead to a very crowded and confusing page which is not very useful IMO
* Second Citing header (without any citing information, duh)

This way we get a much nicer landing page for the documentation.