### PR TITLE
Docs: Fix missing submodules in sphinx documentation

### DIFF
--- a/docs/source/_templates/module.rst
+++ b/docs/source/_templates/module.rst
@@ -75,8 +75,9 @@
    :recursive:
    :template: module.rst
 
-{% for item in modules %}
-{{ item }}
-{%- endfor %}
+    {% for item in modules %}
+    {{ item }}
+    {%- endfor %}
+
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
This was just a stupid indentation error.

I am still quite a noob when it comes to the rest-syntax