### PR TITLE
Fix wrong offset calculation #142

### DIFF
--- a/src/pymovements/events/idt.py
+++ b/src/pymovements/events/idt.py
@@ -111,16 +111,16 @@ def idt(
                 win_end += 1
 
                 # break if we reach end of input data
-                if win_end == len(positions) - 1:
+                if win_end == len(positions):
                     break
 
             # Note a fixation at the centroid of the window points
-            centroid = np.mean(positions[win_start:win_end], axis=0)
+            centroid = np.mean(positions[win_start:win_end - 1], axis=0)
 
             fixations.append({
                 'type': 'fixation',
                 'onset': win_start,
-                'offset': win_end,
+                'offset': win_end - 1,
                 'position': centroid.tolist(),
             })
 

--- a/tests/events/test_idt.py
+++ b/tests/events/test_idt.py
@@ -142,7 +142,7 @@ def test_idt_raises_error(kwargs, expected_error):
                     'type': ['fixation'],
                     'onset': [0],
                     'offset': [99],
-                    'position': [(0.0, 0.0)],
+                    'position': [[0.0, 0.0]],
                 },
             ),
             id='constant_position_single_fixation',
@@ -162,8 +162,8 @@ def test_idt_raises_error(kwargs, expected_error):
                 {
                     'type': 'fixation',
                     'onset': [0, 50],
-                    'offset': [50, 99],  # should be [49, 99]
-                    'position': [(0.18, 0.18), (1.0, 1.0)],  # should be: [(0.0, 0.0), (1.0, 1.0)]
+                    'offset': [49, 99],
+                    'position': [[0.0, 0.0], [1.0, 1.0]],
                 },
             ),
             id='three_steps_two_fixations',
@@ -171,6 +171,7 @@ def test_idt_raises_error(kwargs, expected_error):
     ],
 )
 def test_idt_detects_fixations(kwargs, expected):
+    """Test if idt detects fixations."""
     velocities = pos2vel(kwargs['positions'], sampling_rate=10, method='preceding')
     events = idt(velocities=velocities, **kwargs)
 


### PR DESCRIPTION
## Description

Fix issue #142

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] Change condition for loop to break when reaching the end of data sequence
- [x] Subtract 1 from offset for centroid calculation and fixation offset parameter
- [x] Changed values for tests to correct values

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

Tests with correct values are passing for this fix

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
