### PR TITLE
Transforms: Refactor cut_into_subsequences to split

### DIFF
--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -389,7 +389,7 @@ def split(
         arr_split_list = np.split(arr_instance, split_indices)
 
         # Put the first n elements of split list into output array.
-        arr_split[idx:idx+n] = arr_split_list[:-1]
+        arr_split[idx:idx + n] = arr_split_list[:-1]
         idx += n
 
         if rest > 0 and keep_padded:


### PR DESCRIPTION
## Description

Fixes issue #144 

We now take use of the numpy function  [`np.split()`](https://numpy.org/doc/stable/reference/generated/numpy.split.html)

Moreover, I really despise the current name of the function as its very long and verbose.
I propose to rename the function just simply to `split()`.

## Implemented changes

- [x] use np.split() instead of inner for loop

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Additional test for a batch of two sequences that need to be padded
- [x] Additional test for different value of window_size

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
