### PR TITLE
Remove velocities argument from IDT function

### DIFF
--- a/src/pymovements/events/idt.py
+++ b/src/pymovements/events/idt.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-from pymovements.utils.checks import check_shapes_positions_velocities
-
 
 def dispersion(positions: list[list[float]] | np.ndarray) -> float:
     """
@@ -50,7 +48,6 @@ def dispersion(positions: list[list[float]] | np.ndarray) -> float:
 
 def idt(
         positions: list[list[float]] | list[tuple[float, float]] | np.ndarray,
-        velocities: list[list[float]] | list[tuple[float, float]] | np.ndarray,
         dispersion_threshold: float,
         minimum_duration: int,
 ) -> pl.DataFrame:
@@ -70,8 +67,6 @@ def idt(
     ----------
     positions: array-like, shape (N, 2)
         Continuous 2D position time series
-    velocities: array-like, shape (N, 2)
-        Corresponding continuous 2D velocity time series.
     dispersion_threshold: float
         Threshold for dispersion for a group of consecutive samples to be identified as fixation
     minimum_duration: int
@@ -90,9 +85,7 @@ def idt(
         If duration_threshold is not greater than 0
     """
     positions = np.array(positions)
-    velocities = np.array(velocities)
 
-    check_shapes_positions_velocities(positions=positions, velocities=velocities)
     if dispersion_threshold <= 0:
         raise ValueError('dispersion threshold must be greater than 0')
     if minimum_duration <= 0:

--- a/tests/events/test_idt.py
+++ b/tests/events/test_idt.py
@@ -24,7 +24,6 @@ from polars.testing import assert_frame_equal
 
 from pymovements.events.idt import idt
 from pymovements.synthetic import step_function
-from pymovements.transforms import pos2vel
 
 
 @pytest.mark.parametrize(
@@ -171,7 +170,5 @@ def test_idt_raises_error(kwargs, expected_error):
     ],
 )
 def test_idt_detects_fixations(kwargs, expected):
-    velocities = pos2vel(kwargs['positions'], sampling_rate=10, method='preceding')
-    events = idt(velocities=velocities, **kwargs)
-
+    events = idt(**kwargs)
     assert_frame_equal(events, expected)

--- a/tests/events/test_idt.py
+++ b/tests/events/test_idt.py
@@ -32,17 +32,15 @@ from pymovements.synthetic import step_function
         pytest.param(
             {
                 'positions': None,
-                'velocities': None,
                 'dispersion_threshold': 1,
                 'minimum_duration': 1,
             },
-            ValueError,
+            TypeError,
             id='positions_none_raises_value_error',
         ),
         pytest.param(
             {
                 'positions': [[1, 2], [1, 2]],
-                'velocities': [[1, 2], [1, 2]],
                 'dispersion_threshold': None,
                 'minimum_duration': 1,
             },
@@ -52,7 +50,6 @@ from pymovements.synthetic import step_function
         pytest.param(
             {
                 'positions': [[1, 2], [1, 2]],
-                'velocities': [[1, 2], [1, 2]],
                 'dispersion_threshold': 1,
                 'minimum_duration': None,
             },
@@ -62,27 +59,24 @@ from pymovements.synthetic import step_function
         pytest.param(
             {
                 'positions': 1,
-                'velocities': 1,
                 'dispersion_threshold': 1,
                 'minimum_duration': 1,
             },
-            ValueError,
+            TypeError,
             id='positions_not_array_like_raises_value_error',
         ),
         pytest.param(
             {
                 'positions': [1, 2, 3],
-                'velocities': [1, 2, 3],
                 'dispersion_threshold': 1,
                 'minimum_duration': 1,
             },
-            ValueError,
+            TypeError,
             id='positions_1d_raises_value_error',
         ),
         pytest.param(
             {
                 'positions': [[1, 2, 3], [1, 2, 3]],
-                'velocities': [[1, 2, 3], [1, 2, 3]],
                 'dispersion_threshold': 1,
                 'minimum_duration': 1,
             },
@@ -92,7 +86,6 @@ from pymovements.synthetic import step_function
         pytest.param(
             {
                 'positions': [[1, 2], [1, 2]],
-                'velocities': [[1, 2], [1, 2]],
                 'dispersion_threshold': 0,
                 'minimum_duration': 1,
             },
@@ -102,7 +95,6 @@ from pymovements.synthetic import step_function
         pytest.param(
             {
                 'positions': [[1, 2], [1, 2]],
-                'velocities': [[1, 2], [1, 2]],
                 'dispersion_threshold': 1,
                 'minimum_duration': 0,
             },
@@ -112,7 +104,6 @@ from pymovements.synthetic import step_function
         pytest.param(
             {
                 'positions': [[1, 2], [1, 2]],
-                'velocities': [[1, 2], [1, 2]],
                 'dispersion_threshold': 1,
                 'minimum_duration': 1.0,
             },


### PR DESCRIPTION
## Description

Removed `velocities` argument from idt function since the velocities are not nesessary for the idt algorithm.

## Implemented changes

- [x] Remove `velocities` from function header and all code lines checking the value of this argument
- [ ] Remove the velocity calculation in the idt test functions

## Type of change 

- [x] Bug fix (non-breaking change which fixes an issue)
- 
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
