### PR TITLE
Events: Fix error on empty event list

### DIFF
--- a/src/pymovements/events/engbert.py
+++ b/src/pymovements/events/engbert.py
@@ -27,6 +27,7 @@ from collections.abc import Sized
 import numpy as np
 import polars as pl
 
+from pymovements.events.events import Saccade
 from pymovements.transforms import consecutive
 from pymovements.utils.checks import check_shapes_positions_velocities
 
@@ -116,14 +117,21 @@ def microsaccades(
         for candidate_indices in candidates
     ])
 
-    # Create event dataframe from saccade onset and offsets.
-    event_df = pl.from_dict(
-        {
-            'type': 'saccade',
-            'onset': saccades[:, 0].tolist(),
-            'offset': saccades[:, 1].tolist(),
-        },
-    )
+    if len(saccades) > 0:
+        # Create event dataframe.
+        event_df = pl.from_dict(
+            {
+                'type': 'saccade',
+                'onset': saccades[:, 0].tolist(),
+                'offset': saccades[:, 1].tolist(),
+            },
+            schema=Saccade.schema,
+        )
+
+    else:
+        # Create empty dataframe with correct schema if no events detected.
+        event_df = pl.DataFrame(schema=Saccade.schema)
+
     return event_df
 
 

--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -69,7 +69,10 @@ class Event:
         Starting index of event (included).
     offset: int
         Ending index of event (excluded).
+    schema: polars.SchemaDict
+        Schema for event DataFrame.
     """
+    schema: pl.datatypes.SchemaDict = {'type': pl.Utf8, 'onset': pl.Int64, 'offset': pl.Int64}
 
     def __init__(self, name: str, onset: int, offset: int):
         """
@@ -134,8 +137,12 @@ class Fixation(Event):
         Ending index of event (excluded).
     position: tuple[float, float]
         (x, y) position of fixation
+    schema: polars.SchemaDict
+        Schema for event DataFrame.
     """
     _name = 'fixation'
+
+    schema: pl.datatypes.SchemaDict = {**Event.schema, 'position': pl.List(pl.Float64)}
 
     def __init__(self, onset: int, offset: int, position: tuple[float, float]):
         """
@@ -175,6 +182,8 @@ class Saccade(Event):
         Starting index of event (included).
     offset: int
         Ending index of event (excluded).
+    schema: polars.SchemaDict
+        Schema for event DataFrame.
     """
     _name = 'saccade'
 

--- a/src/pymovements/events/idt.py
+++ b/src/pymovements/events/idt.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
+from pymovements.events.events import Fixation
 from pymovements.utils.checks import check_shapes_positions_velocities
 
 
@@ -130,6 +131,12 @@ def idt(
         else:
             win_start += 1
 
-    event_df = pl.from_dicts(fixations, infer_schema_length=1)
+    if len(fixations) > 0:
+        # Create event dataframe.
+        event_df = pl.from_dicts(fixations, schema=Fixation.schema)
+
+    else:
+        # Create empty dataframe with correct schema if no events detected.
+        event_df = pl.DataFrame(schema=Fixation.schema)
 
     return event_df

--- a/src/pymovements/events/ivt.py
+++ b/src/pymovements/events/ivt.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
+from pymovements.events.events import Fixation
 from pymovements.transforms import consecutive
 from pymovements.transforms import norm
 from pymovements.utils.checks import check_shapes_positions_velocities
@@ -103,10 +104,20 @@ def ivt(
         for fixation in fixations
     ]
 
-    event_df = pl.from_dict({
-        'type': 'fixation',
-        'onset': fixations[:, 0].tolist(),
-        'offset': fixations[:, 1].tolist(),
-        'position': centroids,
-    })
+    if len(fixations) > 0:
+        # Create event dataframe.
+        event_df = pl.from_dict(
+            {
+                'type': 'fixation',
+                'onset': fixations[:, 0].tolist(),
+                'offset': fixations[:, 1].tolist(),
+                'position': centroids,
+            },
+            schema=Fixation.schema,
+        )
+
+    else:
+        # Create empty dataframe with correct schema if no events detected.
+        event_df = pl.DataFrame(schema=Fixation.schema)
+
     return event_df

--- a/tests/events/test_engbert.py
+++ b/tests/events/test_engbert.py
@@ -25,6 +25,7 @@ from polars.testing import assert_frame_equal
 
 from pymovements.events.engbert import compute_threshold
 from pymovements.events.engbert import microsaccades
+from pymovements.events.events import Saccade
 from pymovements.synthetic import step_function
 
 
@@ -77,6 +78,20 @@ def test_microsaccades_raises_error(kwargs, expected):
                     values=[(9, 9), (0, 0)],
                     start_value=(0, 0),
                 ),
+                'threshold': 10,
+            },
+            pl.DataFrame(schema=Saccade.schema),
+            id='two_steps_one_saccade_high_threshold_no_events',
+        ),
+        pytest.param(
+            {
+                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
+                'velocities': step_function(
+                    length=100,
+                    steps=[40, 50],
+                    values=[(9, 9), (0, 0)],
+                    start_value=(0, 0),
+                ),
                 'threshold': 1e-5,
             },
             pl.DataFrame(
@@ -85,6 +100,7 @@ def test_microsaccades_raises_error(kwargs, expected):
                     'onset': [40],
                     'offset': [49],
                 },
+                schema=Saccade.schema,
             ),
             id='two_steps_one_saccade',
         ),
@@ -105,6 +121,7 @@ def test_microsaccades_raises_error(kwargs, expected):
                     'onset': [20, 70],
                     'offset': [29, 79],
                 },
+                schema=Saccade.schema,
             ),
             id='four_steps_two_saccades',
         ),


### PR DESCRIPTION
## Description

All event detection methods raised an index error on generating the event dataframe when there were no events detected.

## Implemented changes

Insert a description of the changes implemented in the pull request.

For each event detection method: 
- [x] Added check for empty event list and create empty dataframe with correct schema if empty

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] microsaccades(): Test constant position leads to empty event dataframe with correct schema
- [x] ivt(): Test constantly changing position leads to empty event dataframe with correct schema
- [x] idt(): Test constantly changing position leads to empty event dataframe with correct schema. This test produces unexpected results and will be handled in issue #186

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
