### PR TITLE
Events: Add method to clear event dataframes

### DIFF
--- a/src/pymovements/datasets/dataset.py
+++ b/src/pymovements/datasets/dataset.py
@@ -410,7 +410,8 @@ class Dataset:
             ``auto`` is passed, ``left`` will only be chosen if the right eye is not available in
             the gaze data frame.
         clear : bool
-            If ``True``, event DataFrame will be cleared before event detection.
+            If ``True``, event DataFrame will be overwritten with new DataFrame instead of being
+             merged into the existing one.
         verbose : bool
             If ``True``, show progress bar.
         **kwargs :

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from pymovements.datasets.dataset import Dataset
+from pymovements.events.events import Event
+
+
+@pytest.mark.parametrize(
+    'events_init, events_expected',
+    [
+        pytest.param(
+            [],
+            [],
+            id='empty_list_stays_empty_list',
+        ),
+        pytest.param(
+            [pl.DataFrame(schema=Event.schema)],
+            [pl.DataFrame(schema=Event.schema)],
+            id='empty_df_stays_empty_df',
+        ),
+        pytest.param(
+            [pl.DataFrame({'type': ['event'], 'onset': [0], 'offset': [99]}, schema=Event.schema)],
+            [pl.DataFrame(schema=Event.schema)],
+            id='single_instance_filled_df_gets_cleared_to_empty_df',
+        ),
+        pytest.param(
+            [
+                pl.DataFrame(
+                    {'type': ['event'], 'onset': [0], 'offset': [99]},
+                    schema=Event.schema,
+                ),
+                pl.DataFrame(
+                    {'type': ['event'], 'onset': [0], 'offset': [99]},
+                    schema=Event.schema,
+                ),
+            ],
+            [pl.DataFrame(schema=Event.schema), pl.DataFrame(schema=Event.schema)],
+            id='two_instance_filled_df_gets_cleared_to_two_empty_dfs',
+        ),
+    ],
+)
+def test_clear_events(events_init, events_expected):
+    """Test if idt detects fixations."""
+    dataset = Dataset(root='data')
+    dataset.events = events_init
+    dataset.clear_events()
+
+    if isinstance(events_init, list) and not events_init:
+        assert dataset.events == events_expected
+
+    else:
+        for events_df_result, events_df_expected in zip(dataset.events, events_expected):
+            assert_frame_equal(events_df_result, events_df_expected)

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+"""Test all functionality in pymovements.datasets.dataset."""
 import polars as pl
 import pytest
 from polars.testing import assert_frame_equal


### PR DESCRIPTION
## Description

This adds the possibility to manually clear the event dataframe.
Additionally, a `clear` flag is added to the `detect_events()` method to clear the dataframe instead of merging new detections.

## Implemented changes

- [x] Add `Dataset.clear_events()`
- [x] Add argument `clear: bool = False` to `Dataset.detect_events()`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change is or requires a documentation update

## How Has This Been Tested?
Only the `clear()` method has been tested. Testing `detect_events()` is a separate part on my agenda.

- [x] Empty dataframes stay empty dataframes
- [x] list of a single event dataframe is cleared to a list of a single empty dataframe
- [x] list of a two event dataframes is cleared to a list of two empty dataframes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
