### PR TITLE
CI: Install pandoc for docs job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Install pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+        with:
+          pandoc-version: '2.19.2'
       - name: Install base python for tox
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Pandoc is needed for integrating jupyter notebooks into the sphinx documentation. 