### PR TITLE
Package: Downgrade sphinx for python3.7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ docs = [
   "pandoc",
   "pybtex",
   "pydata-sphinx-theme>=0.12",
-  "sphinx>=6.0.0",
+  "sphinx>=5.3.0",
   "sphinx-copybutton>=0.4.0",
   "sphinx_mdinclude>=0.5.0",
   "sphinxcontrib.datatemplates>=0.9.0",


### PR DESCRIPTION
binder uses python 3.7 by default and somehow sphinx 6.0.0 is only available for py38+.
Which  is strange actually as this should have been detected by CI?

Anyway, this does not work (master):
https://mybinder.org/v2/gh/aeye-lab/pymovements/HEAD

and this works (this branch):
https://mybinder.org/v2/gh/aeye-lab/pymovements/hotfix/sphinx-version