### PR TITLE
CI: Run tox doc builds with python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install base python for tox
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.7"
       - name: Install tox
         run: python -m pip install tox
       - name: Setup test environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ docs = [
   "pandoc",
   "pybtex",
   "pydata-sphinx-theme>=0.12",
-  "sphinx>=6.0.0",
+  "sphinx>=5.3.0",
   "sphinx-copybutton>=0.4.0",
   "sphinx_mdinclude>=0.5.0",
   "sphinxcontrib.datatemplates>=0.9.0",


### PR DESCRIPTION
CI for our documentation is now running on python 3.7 instead of 3.9.

This is related to the PR #208
This was probably the first time the pymovements docs were build on py37 and it instantly failed