### PR TITLE
Docs: Fix missing logo bug in sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -137,8 +137,8 @@ html_theme_options = {
         },
     ],
     'logo': {
-        'image_light': 'logo.svg',
-        'image_dark': 'logo.svg',
+        'image_light': 'https://raw.githubusercontent.com/aeye-lab/pymovements/main/docs/source/_static/logo.svg',  # noqa: E501
+        'image_dark': 'https://raw.githubusercontent.com/aeye-lab/pymovements/main/docs/source/_static/logo.svg',  # noqa: E501
     },
 }
 


### PR DESCRIPTION
I'm totally clueless how this bug was introduced.

By setting the `html_static_path` further up, there shouldn't be a need for using absolute paths at all..
This is just a quick fix and I will look at some point in the future how to use relative paths here again.