### PR TITLE
Datasets: Download resources to download path

### DIFF
--- a/src/pymovements/datasets/public_dataset.py
+++ b/src/pymovements/datasets/public_dataset.py
@@ -151,7 +151,7 @@ class PublicDataset(Dataset, metaclass=ABCMeta):
                 try:
                     download_file(
                         url=url,
-                        dirpath=self.root,
+                        dirpath=self.downloads_rootpath,
                         filename=resource['filename'],
                         md5=resource['md5'],
                     )


### PR DESCRIPTION
`PublicDataset.extract()` correctly expects files to be in download directory but they are currently downloaded into the root directory.