### PR TITLE
 Utils: Add paths.match_filepaths()

### DIFF
--- a/src/pymovements/datasets/dataset.py
+++ b/src/pymovements/datasets/dataset.py
@@ -30,7 +30,7 @@ from tqdm.auto import tqdm
 from pymovements.base import Experiment
 from pymovements.events.events import Event
 from pymovements.events.events import EventDetectionCallable
-from pymovements.utils.paths import get_filepaths
+from pymovements.utils.paths import match_filepaths
 
 
 class Dataset:
@@ -171,32 +171,12 @@ class Dataset:
         RuntimeError
             If an error occurred during matching filenames or no files have been found.
         """
-        filename_regex = re.compile(self._filename_regex)
-
         # Get all filepaths that match regular expression.
-        csv_filepaths = get_filepaths(
+        fileinfo_dicts = match_filepaths(
             path=self.raw_rootpath,
-            regex=filename_regex,
+            regex=re.compile(self._filename_regex),
+            relative=True,
         )
-
-        # Parse fileinfo from filenames.
-        fileinfo_dicts: list[dict[str, Any]] = []
-        for filepath in csv_filepaths:
-
-            # All csv_filepaths already match the filename_regex.
-            match = filename_regex.match(filepath.name)
-
-            # This should never happen but mypy will complain otherwise.
-            if match is None:
-                raise RuntimeError(
-                    f'file {filepath} did not match regular expression {filename_regex}',
-                )
-
-            # We use the groupdict of the match as a base and add the filepath.
-            fileinfo_dict = match.groupdict()
-
-            fileinfo_dict['filepath'] = str(filepath.relative_to(self.raw_rootpath))
-            fileinfo_dicts.append(fileinfo_dict)
 
         if len(fileinfo_dicts) == 0:
             raise RuntimeError(f'no matching files found in {self.raw_rootpath}')

--- a/src/pymovements/utils/paths.py
+++ b/src/pymovements/utils/paths.py
@@ -77,3 +77,59 @@ def get_filepaths(
                 continue
             filepaths.append(childpath)
     return filepaths
+
+
+def match_filepaths(
+        path: str | Path,
+        regex: re.Pattern,
+        relative: bool = True,
+        relative_anchor: Path | None = None,
+):
+    """Traverse path and match regular expression.
+
+    Parameters
+    ----------
+    path: str | Path
+        Root path to be traversed.
+    regex: re.Pattern, optional
+        Regular expression filenames will be matched against.
+    relative: bool
+        If True, specify filepath as relative to root path.
+    relative_anchor: Path, optional
+        Specifies root path in case of ``relative == True``. If None, ``path`` will be chosen
+        as `relative_anchor` for recursive calls.
+
+    Returns
+    -------
+    list[dict[str, str]]
+        Each entry contains the match group dictionary of the regular expression.
+    """
+    path = Path(path)
+    if not path.is_dir():
+        return []
+
+    if relative and relative_anchor is None:
+        relative_anchor = path
+
+    match_dicts: list[dict[str, str]] = []
+    for childpath in path.iterdir():
+        if childpath.is_dir():
+            recursive_results = match_filepaths(
+                path=childpath, regex=regex,
+                relative=relative, relative_anchor=relative_anchor,
+            )
+            match_dicts.extend(recursive_results)
+        else:
+            match = regex.match(childpath.name)
+            if match is not None:
+                match_dict = match.groupdict()
+
+                filepath = childpath
+                if relative:
+                    if relative_anchor is None:
+                        relative_anchor = path
+                    filepath = filepath.relative_to(relative_anchor)
+
+                match_dict['filepath'] = str(filepath)
+                match_dicts.append(match_dict)
+    return match_dicts

--- a/src/pymovements/utils/paths.py
+++ b/src/pymovements/utils/paths.py
@@ -84,7 +84,7 @@ def match_filepaths(
         regex: re.Pattern,
         relative: bool = True,
         relative_anchor: Path | None = None,
-):
+) -> list[dict[str, str]]:
     """Traverse path and match regular expression.
 
     Parameters
@@ -103,10 +103,15 @@ def match_filepaths(
     -------
     list[dict[str, str]]
         Each entry contains the match group dictionary of the regular expression.
+
+    Raises
+    ------
+    ValueError
+        If ``path`` does not point to a directory.
     """
     path = Path(path)
     if not path.is_dir():
-        return []
+        raise ValueError(f'path must point to a directory, but points to a file (path = {path})')
 
     if relative and relative_anchor is None:
         relative_anchor = path

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -345,12 +345,6 @@ def test_init_exceptions(init_kwargs, exception):
     'init_kwargs, load_kwargs, exception',
     [
         pytest.param(
-            {'root': '/not/a/real/path'},
-            {},
-            RuntimeError,
-            id='no_files_present',
-        ),
-        pytest.param(
             {},
             {'subset': 1},
             TypeError,
@@ -382,6 +376,17 @@ def test_load_exceptions(init_kwargs, load_kwargs, exception, dataset_configurat
 
     with pytest.raises(exception):
         dataset.load(**load_kwargs)
+
+
+def test_load_no_files_raises_exception(dataset_configuration):
+    init_kwargs = {**dataset_configuration['init_kwargs']}
+    dataset = Dataset(**init_kwargs)
+
+    shutil.rmtree(dataset.raw_rootpath, ignore_errors=True)
+    dataset.raw_rootpath.mkdir()
+
+    with pytest.raises(RuntimeError):
+        dataset.load()
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -23,6 +23,7 @@ Test pymovements paths.
 import pathlib
 import re
 import unittest
+from pathlib import Path
 
 import pytest
 
@@ -123,21 +124,21 @@ def test_get_filepaths_expected_output(
             re.compile('.*'),
             ['tmp_dir'],
             ['foo.txt'],
-            [{'filepath': 'tmp_dir/foo.txt'}],
+            [{'filepath': str(Path('tmp_dir/foo.txt'))}],
             id='match_all_no_groups_single_file',
         ),
         pytest.param(
             re.compile('.*'),
             ['tmp_dir'],
             ['foo.txt', 'bar.py'],
-            [{'filepath': 'tmp_dir/foo.txt'}, {'filepath': 'tmp_dir/bar.py'}],
+            [{'filepath': str(Path('tmp_dir/foo.txt'))}, {'filepath': str(Path('tmp_dir/bar.py'))}],
             id='match_all_no_groups_two_files',
         ),
         pytest.param(
             re.compile('foo'),
             ['tmp_dir'],
             ['foo.txt', 'bar.py'],
-            [{'filepath': 'tmp_dir/foo.txt'}],
+            [{'filepath': str(Path('tmp_dir/foo.txt'))}],
             id='match_substring_single_file_out_of_two_no_groups',
         ),
         pytest.param(
@@ -145,8 +146,8 @@ def test_get_filepaths_expected_output(
             ['a'],
             ['123_456.ext', '456_789.ext'],
             [
-                {'foo': '123', 'bar': '456', 'filepath': 'a/123_456.ext'},
-                {'foo': '456', 'bar': '789', 'filepath': 'a/456_789.ext'},
+                {'foo': '123', 'bar': '456', 'filepath': str(Path('a/123_456.ext'))},
+                {'foo': '456', 'bar': '789', 'filepath': str(Path('a/456_789.ext'))},
             ],
             id='match_groups_two_files',
         ),

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -22,10 +22,12 @@ Test pymovements paths.
 """
 import pathlib
 import re
+import unittest
 
 import pytest
 
 from pymovements.utils.paths import get_filepaths
+from pymovements.utils.paths import match_filepaths
 
 
 def test_get_filepaths_mut_excl_extension_and_regex_error():
@@ -45,13 +47,13 @@ def test_get_filepaths_mut_excl_extension_and_regex_error():
             None,
             re.compile('regex'),
             [],
-            id='regex empty dir',
+            id='regex_empty_dir',
         ),
         pytest.param(
             'extension',
             None,
             [],
-            id='extension empty dir',
+            id='extension_empty_dir',
         ),
     ],
 )
@@ -60,9 +62,6 @@ def test_get_filepaths_empty_directory(
         regex,
         expected_paths,
 ):
-    """
-    Test mutually exclusive extension and regex in `get_filepaths`.
-    """
     assert get_filepaths(path='tmp', extension=extension, regex=regex) == expected_paths
 
 
@@ -84,7 +83,7 @@ def create_directory(tmp_path, sub_dirs, files):
             ['tmp_dir'],
             ['foo.txt', 'bar.py'],
             ['tmp_dir/foo.txt'],
-            id='extension regex get filepaths list',
+            id='extension_regex_get_filepaths_list',
         ),
         pytest.param(
             None,
@@ -92,11 +91,11 @@ def create_directory(tmp_path, sub_dirs, files):
             ['tmp_dir'],
             ['foo.txt', 'foo.py', 'bar.py'],
             ['tmp_dir/foo.txt', 'tmp_dir/foo.py'],
-            id='regex get filepaths list',
+            id='regex_get_filepaths_list',
         ),
     ],
 )
-def test_get_filepaths_is_dir(
+def test_get_filepaths_expected_output(
         extension,
         regex,
         tmp_path,
@@ -104,10 +103,85 @@ def test_get_filepaths_is_dir(
         files,
         expected_paths,
 ):
-    """
-    Test `get_filepaths` list creation.
-    """
     create_directory(tmp_path, sub_dirs, files)
     ret = get_filepaths(path=tmp_path, extension=extension, regex=regex)
     expected_list = [tmp_path / pathlib.Path(expected_path) for expected_path in expected_paths]
     assert sorted(ret) == sorted(expected_list)
+
+
+@pytest.mark.parametrize(
+    ('regex', 'sub_dirs', 'files', 'expected_dicts'),
+    [
+        pytest.param(
+            re.compile('.*'),
+            ['tmp_dir'],
+            [],
+            [],
+            id='empty_directory_empty_list',
+        ),
+        pytest.param(
+            re.compile('.*'),
+            ['tmp_dir'],
+            ['foo.txt'],
+            [{'filepath': 'tmp_dir/foo.txt'}],
+            id='match_all_no_groups_single_file',
+        ),
+        pytest.param(
+            re.compile('.*'),
+            ['tmp_dir'],
+            ['foo.txt', 'bar.py'],
+            [{'filepath': 'tmp_dir/foo.txt'}, {'filepath': 'tmp_dir/bar.py'}],
+            id='match_all_no_groups_two_files',
+        ),
+        pytest.param(
+            re.compile('foo'),
+            ['tmp_dir'],
+            ['foo.txt', 'bar.py'],
+            [{'filepath': 'tmp_dir/foo.txt'}],
+            id='match_substring_single_file_out_of_two_no_groups',
+        ),
+        pytest.param(
+            re.compile(r'(?P<foo>\d+)_(?P<bar>\d+).ext'),
+            ['a'],
+            ['123_456.ext', '456_789.ext'],
+            [
+                {'foo': '123', 'bar': '456', 'filepath': 'a/123_456.ext'},
+                {'foo': '456', 'bar': '789', 'filepath': 'a/456_789.ext'},
+            ],
+            id='match_groups_two_files',
+        ),
+    ],
+)
+def test_match_filepaths(
+        regex,
+        sub_dirs,
+        files,
+        expected_dicts,
+        tmp_path,
+):
+    create_directory(tmp_path, sub_dirs, files)
+    result_dicts = match_filepaths(path=tmp_path, regex=regex)
+
+    case = unittest.TestCase()
+    case.assertCountEqual(result_dicts, expected_dicts)
+
+
+def test_match_filepaths_not_relative(tmp_path):
+    create_directory(tmp_path, ['tmp_dir'], ['foo.txt'])
+    result_dicts = match_filepaths(path=tmp_path, regex=re.compile('.*'), relative=False)
+
+    expected_dicts = [{'filepath': str(tmp_path / 'tmp_dir/foo.txt')}]
+    case = unittest.TestCase()
+    case.assertCountEqual(result_dicts, expected_dicts)
+
+
+def test_match_filepaths_no_directory_raises_value_error(tmp_path):
+    create_directory(tmp_path, ['tmp_dir'], ['foo.txt'])
+    filepath = tmp_path / 'tmp_dir' / 'foo.txt'
+
+    with pytest.raises(ValueError) as excinfo:
+        match_filepaths(path=filepath, regex=re.compile('.*'))
+    msg, = excinfo.value.args
+
+    assert 'must point to a directory' in msg
+    assert str(filepath) in msg


### PR DESCRIPTION
## Description

This function is similar to get_filepaths(),
but returns a list of match groupdicts.

This makes it possible to get rid of an unreachable Exception in Dataset.

## Implemented changes

- [x] Add paths.match_filepaths()
- [x] Use match_filepaths() in Dataset.infer_fileinfo()

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change is or requires a documentation update

## How Has This Been Tested?

Currently no tests written for this.
I will wait for tests to adjust from #178

- [x] Add tests!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
