### PR TITLE
License: Update year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2023 The pymovements Project Authors
+Copyright (c) 2022 The pymovements Project Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The `insert-license` pre-commit hook gets confused by the year range in the license file.

Previously this lead to the year `2023-2023` for new files.

Now files that are created this year will get `2023` in the license header.
Files created last year but modified this year will get `2022-2023` in the license header.