### PR TITLE
Tests: 100% coverage for transforms.py

### DIFF
--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -307,6 +307,12 @@ def norm(arr: np.ndarray, axis: int | None = None) -> np.ndarray | Any:
     -------
     np.ndarray
 
+    Raises
+    ------
+    ValueError
+        If no axis is given but the array dimensions are lager than 3.
+        In that case the axis cannot be inferred.
+
     Examples
     --------
     >>> arr = np.array([[1., 1., 1., 1., 1., 1.], [1., 1., 1., 1., 1., 1.]])

--- a/src/pymovements/transforms.py
+++ b/src/pymovements/transforms.py
@@ -87,6 +87,22 @@ def pix2deg(
     ...    origin='center',
     ... )
     array([[ 3.07379946, 20.43909054]])
+
+    If the eye-movement of both eyes was recorded, the input array must contain
+    first the x- and y-coordinates of one eye and then the x- and y-coordinates
+    of the other eye as shown in the example below.
+
+    >>> x_left, y_left = 123.0, 865.0
+    >>> x_right, y_right = 183.0, 865.0
+    >>> arr = [(x_left, y_left, x_right, y_right)]
+    >>> pix2deg(
+    ...    arr=arr,
+    ...    screen_px=(1280, 1024),
+    ...    screen_cm=(38.0, 30.0),
+    ...    distance_cm=68.0,
+    ...    origin='center',
+    ... )
+    array([[ 3.07379946, 20.43909054,  4.56790364, 20.43909054]])
     """
     if arr is None:
         raise TypeError('arr must not be None')
@@ -308,6 +324,14 @@ def norm(arr: np.ndarray, axis: int | None = None) -> np.ndarray | Any:
         # shape is assumed to be (n_batches, 2, sequence_length)
         elif arr.ndim == 3:
             axis = 1
+
+        else:
+            raise ValueError(
+                f'Axis can not be inferred in case of more than 3 '
+                f'input array dimensions (arr.shape={arr.shape}).'
+                f' Either reduce the number of input array '
+                f'dimensions or specify `axis` explicitly.',
+            )
 
     return np.linalg.norm(arr, axis=axis)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -575,13 +575,17 @@ def test_pos2vel_stepped_input_returns(params, expected_value):
         pytest.param(
             {'method': 'savitzky_golay', 'window_length': 7, 'polyorder': 2, 'sampling_rate': 1},
             np.concatenate([
-                np.array([[0.71428571, 0.71428571],
-                          [0.80952381, 0.80952381],
-                          [0.9047619, 0.9047619]]),
+                np.array([
+                    [0.71428571, 0.71428571],
+                    [0.80952381, 0.80952381],
+                    [0.9047619, 0.9047619],
+                ]),
                 np.ones((94, 2)),
-                np.array([[0.9047619, 0.9047619],
-                          [0.80952381, 0.80952381],
-                          [0.71428571, 0.71428571]]),
+                np.array([
+                    [0.9047619, 0.9047619],
+                    [0.80952381, 0.80952381],
+                    [0.71428571, 0.71428571],
+                ]),
             ]),
             id='method_savitzky_golay_linear_velocity_2d_input',
         ),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -194,14 +194,25 @@ screen_cm_2d = [100, 100]
         ),
         pytest.param(
             {
-                'arr': np.zeros((n_coords, 3)),
-                'screen_px': [1, 1, 1],
+                'arr': np.zeros((n_coords, 4)),
+                'screen_px': [1, 1],
                 'screen_cm': [1, 1, 1],
                 'distance_cm': screen_cm_1d,
                 'origin': 'center',
             },
             ValueError,
             id='list_coords_4d_screen_cm_not_2d_raises_value_error',
+        ),
+        pytest.param(
+            {
+                'arr': np.zeros((n_coords, 4)),
+                'screen_px': [1, 1],
+                'screen_cm': [1, 1],
+                'distance_cm': screen_cm_1d,
+                'origin': 'upper right',
+            },
+            ValueError,
+            id='invalid_origin_str_raises_value_error',
         ),
     ],
 )
@@ -388,6 +399,17 @@ def test_pix2deg_raises_error(kwargs, expected_error):
             },
             np.array([[0.0, 0.0]] * n_coords),
             id='nparray_of_zero_coords_2d',
+        ),
+        pytest.param(
+            {
+                'arr': np.array([[0, 0, 0, 0]] * n_coords),
+                'screen_px': screen_px_2d,
+                'screen_cm': screen_cm_2d,
+                'distance_cm': screen_cm_1d,
+                'origin': 'center',
+            },
+            np.array([[0.0, 0.0, 0.0, 0.0]] * n_coords),
+            id='nparray_of_zero_coords_4d',
         ),
     ],
 )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -209,7 +209,7 @@ screen_cm_2d = [100, 100]
                 'screen_px': screen_px_2d,
                 'screen_cm': screen_px_2d,
                 'distance_cm': screen_cm_1d,
-                'origin': 'upper right',
+                'origin': 'invalid',
             },
             ValueError,
             id='invalid_origin_str_raises_value_error',
@@ -475,7 +475,7 @@ def test_pix2deg_returns(kwargs, expected_value):
                 'method': 'smooth',
             },
             ValueError,
-            id='wrong_dimensions_input_arr',
+            id='wrong_dimensions_input_arr_raises_value_error',
         ),
         pytest.param(
             {
@@ -484,7 +484,7 @@ def test_pix2deg_returns(kwargs, expected_value):
                 'kwargs': {},
             },
             ValueError,
-            id='kwargs_passed_but_method_not_savitzky_golay',
+            id='kwargs_passed_but_method_not_savitzky_golay_raises_value_error',
         ),
     ],
 )
@@ -591,7 +591,7 @@ def test_pos2vel_stepped_input_returns(params, expected_value):
         ),
     ],
 )
-def test_pos2vel_stepped_input_returns_savitzky_golay(params, expected_value):
+def test_pos2vel_2d_stepped_input_returns(params, expected_value):
     N = 100
     x = np.linspace(0, N - 2, N // 2)
     x = np.repeat(x, 4)
@@ -646,7 +646,7 @@ def test_norm(params, expected_value):
         pytest.param(
             {'arr': np.ones((2, 2, 5, 5)), 'axis': None},
             ValueError,
-            id='4_dim_array_no_axis_raises_exception',
+            id='4_dim_array_no_axis_raises_value_error',
         ),
     ],
 )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -181,6 +181,28 @@ screen_cm_2d = [100, 100]
             ValueError,
             id='list_coords_3d_raises_value_error',
         ),
+        pytest.param(
+            {
+                'arr': np.zeros((n_coords, 4)),
+                'screen_px': [1, 1, 1],
+                'screen_cm': [1, 1, 1],
+                'distance_cm': screen_cm_1d,
+                'origin': 'center',
+            },
+            ValueError,
+            id='list_coords_4d_screen_px_not_2d_raises_value_error',
+        ),
+        pytest.param(
+            {
+                'arr': np.zeros((n_coords, 3)),
+                'screen_px': [1, 1, 1],
+                'screen_cm': [1, 1, 1],
+                'distance_cm': screen_cm_1d,
+                'origin': 'center',
+            },
+            ValueError,
+            id='list_coords_4d_screen_cm_not_2d_raises_value_error',
+        ),
     ],
 )
 def test_pix2deg_raises_error(kwargs, expected_error):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -575,9 +575,13 @@ def test_pos2vel_stepped_input_returns(params, expected_value):
         pytest.param(
             {'method': 'savitzky_golay', 'window_length': 7, 'polyorder': 2, 'sampling_rate': 1},
             np.concatenate([
-                np.array([[0.71428571, 0.71428571], [0.80952381, 0.80952381], [0.9047619, 0.9047619]]),
+                np.array([[0.71428571, 0.71428571],
+                          [0.80952381, 0.80952381],
+                          [0.9047619, 0.9047619]]),
                 np.ones((94, 2)),
-                np.array([[0.9047619, 0.9047619], [0.80952381, 0.80952381], [0.71428571, 0.71428571]]),
+                np.array([[0.9047619, 0.9047619],
+                          [0.80952381, 0.80952381],
+                          [0.71428571, 0.71428571]]),
             ]),
             id='method_savitzky_golay_linear_velocity_2d_input',
         ),


### PR DESCRIPTION
## Description

I added the missing test cases for transforms.py. In addition, I included how to handle one more case in norm(), see below under new functionality.

Fixes issue #180 

## Implemented changes

I wrote the test as specified here:

- [x] 100% test coverage of transforms.py
  - [x] pix2deg()
    - [x] test 4 channel input
    - [x] test 4 channel input with wrong screen dimensions
    - [x] test invalid origin string
  - [x] pos2vel()
    - [x] wrong dimensions for arr
    - [x] kwargs passed but not savitzky golay
    - [x] savitzky golay two channel arr
  - [x] norm()
    - [x] arr.ndim == 3 and axis == None
    - [x] arr.ndim == 4 and axis == None
    - [x] arr.ndim == 4 and axis == 2
    
New functionality:
- [x] add additional raise of ValueError in norm() if `axis == None` and `arr.ndim > 3`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
