### PR TITLE
Tests: improve test coverage for pymovement.utils.checks to account for error messages

### DIFF
--- a/tests/utils/test_checks.py
+++ b/tests/utils/test_checks.py
@@ -33,18 +33,24 @@ from pymovements.utils.checks import check_shapes_positions_velocities
     [
         pytest.param(5, None, '', id='non_zero_single_variable_raises_no_error'),
         pytest.param(
-            0, ValueError,
-            'variable must not be zero', id='zero_single_variable_raises_value_error',
+            0,
+            ValueError,
+            'variable must not be zero',
+            id='zero_single_variable_raises_value_error',
         ),
         pytest.param([1, 2, 3], None, '', id='non_zero_list_raises_no_error'),
         pytest.param(
-            [1, 0, 3], ValueError,
-            'each component in variable must not be zero', id='zero_list_raises_value_error',
+            [1, 0, 3],
+            ValueError,
+            'each component in variable must not be zero',
+            id='zero_list_raises_value_error',
         ),
         pytest.param(np.array([1, 2, 3]), None, '', id='non_zero_np_array_raises_no_error'),
         pytest.param(
-            np.array([1, 0, 3]), ValueError,
-            'each component in variable must not be zero', id='zero_np_array_raises_value_error',
+            np.array([1, 0, 3]),
+            ValueError,
+            'each component in variable must not be zero',
+            id='zero_np_array_raises_value_error',
         ),
     ],
 )

--- a/tests/utils/test_checks.py
+++ b/tests/utils/test_checks.py
@@ -29,58 +29,74 @@ from pymovements.utils.checks import check_shapes_positions_velocities
 
 
 @pytest.mark.parametrize(
-    'variable, expected_error',
+    'variable, expected_error, expected_err_msg',
     [
-        pytest.param(5, None, id='non_zero_single_variable_raises_no_error'),
-        pytest.param(0, ValueError, id='zero_single_variable_raises_value_error'),
-        pytest.param([1, 2, 3], None, id='non_zero_list_raises_no_error'),
-        pytest.param([1, 0, 3], ValueError, id='zero_list_raises_value_error'),
-        pytest.param(np.array([1, 2, 3]), None, id='non_zero_np_array_raises_no_error'),
-        pytest.param(np.array([1, 0, 3]), ValueError, id='zero_np_array_raises_value_error'),
+        pytest.param(5, None, '', id='non_zero_single_variable_raises_no_error'),
+        pytest.param(
+            0, ValueError,
+            'variable must not be zero', id='zero_single_variable_raises_value_error',
+        ),
+        pytest.param([1, 2, 3], None, '', id='non_zero_list_raises_no_error'),
+        pytest.param(
+            [1, 0, 3], ValueError,
+            'each component in variable must not be zero', id='zero_list_raises_value_error',
+        ),
+        pytest.param(np.array([1, 2, 3]), None, '', id='non_zero_np_array_raises_no_error'),
+        pytest.param(
+            np.array([1, 0, 3]), ValueError,
+            'each component in variable must not be zero', id='zero_np_array_raises_value_error',
+        ),
     ],
 )
-def test_check_no_zeros_raises_error(variable, expected_error):
+def test_check_no_zeros_raises_error(variable, expected_error, expected_err_msg):
     """
     Test that check_no_zeros() only raises an Exception if there are zeros in the input array.
     """
     if expected_error is None:
         check_no_zeros(variable)
     else:
-        with pytest.raises(expected_error):
+        with pytest.raises(expected_error) as excinfo:
             check_no_zeros(variable)
+        msg, = excinfo.value.args
+        assert msg == expected_err_msg
 
 
 @pytest.mark.parametrize(
-    'arr, expected_error',
+    'arr, expected_error, expected_err_msg',
     [
         pytest.param(
             np.array([[1, 2], [3, 4]]),
             None,
+            '',
             id='no_nans_raises_no_error',
         ),
         pytest.param(
             np.array([[1, 2], [np.nan, np.nan]]),
             None,
+            '',
             id='nans_same_time_steps_raises_no_error',
         ),
         pytest.param(
             np.array([[np.nan, 2], [np.nan, 4]]),
             ValueError,
+            'nans must occur at the same steps of horizontal and vertical direction',
             id='nans_different_time_steps_raises_value_error',
         ),
         pytest.param(
             np.array([[np.nan, 2], [3, 4]]),
             ValueError,
+            'nans must occur at the same steps of horizontal and vertical direction',
             id='nans_only_left_channel_raises_value_error',
         ),
         pytest.param(
             np.array([[1, np.nan], [3, 4]]),
             ValueError,
+            'nans must occur at the same steps of horizontal and vertical direction',
             id='nans_only_right_channel_raises_value_error',
         ),
     ],
 )
-def test_check_nan_both_channels_raises_error(arr, expected_error):
+def test_check_nan_both_channels_raises_error(arr, expected_error, expected_err_msg):
     """
     Test that check_nan_both_channels() only raises an Exception if all nans
     occur at the same time step for both channels.
@@ -88,13 +104,15 @@ def test_check_nan_both_channels_raises_error(arr, expected_error):
     if expected_error is None:
         check_nan_both_channels(arr)
     else:
-        with pytest.raises(expected_error):
+        with pytest.raises(expected_error) as excinfo:
             check_nan_both_channels(arr)
+        msg, = excinfo.value.args
+        assert msg == expected_err_msg
 
 
 # Test check_shapes_positions_velocities
 @pytest.mark.parametrize(
-    'kwargs, expected_error',
+    'kwargs, expected_error, expected_err_msg',
     [
         pytest.param(
             {
@@ -102,6 +120,7 @@ def test_check_nan_both_channels_raises_error(arr, expected_error):
                 'velocities': np.array([[1, 2], [3, 4]]),
             },
             None,
+            '',
             id='positions_and_velocities_shape_N_2_raises_no_error',
         ),
         pytest.param(
@@ -110,6 +129,7 @@ def test_check_nan_both_channels_raises_error(arr, expected_error):
                 'velocities': np.array([1, 2, 3, 4]),
             },
             ValueError,
+            'velocities must have shape (N, 2) but have shape (4,)',
             id='positions_shape_N_2_velocities_not_shape_N_2_raises_value_error',
         ),
         pytest.param(
@@ -118,6 +138,7 @@ def test_check_nan_both_channels_raises_error(arr, expected_error):
                 'velocities': np.array([[1, 2], [3, 4]]),
             },
             ValueError,
+            'positions must have shape (N, 2) but have shape (4,)',
             id='positions_not_shape_N_2_velocities_shape_N_2_raises_value_error',
         ),
         pytest.param(
@@ -126,6 +147,7 @@ def test_check_nan_both_channels_raises_error(arr, expected_error):
                 'velocities': np.array([1, 2, 3, 4]),
             },
             ValueError,
+            'positions must have shape (N, 2) but have shape (4,)',
             id='positions_and_velocities_not_shape_N_2_raises_value_error',
         ),
         pytest.param(
@@ -134,11 +156,13 @@ def test_check_nan_both_channels_raises_error(arr, expected_error):
                 'velocities': np.array([[1, 2], [3, 4], [5, 6]]),
             },
             ValueError,
+            'shape of positions (2, 2) does not match'
+            ' shape of velocities (3, 2)',
             id='positions_and_velocities_N_2_but_different_lengths_raises_value_error',
         ),
     ],
 )
-def test_check_shapes_positions_velocities_raises_error(kwargs, expected_error):
+def test_check_shapes_positions_velocities_raises_error(kwargs, expected_error, expected_err_msg):
     """
     Test that check_shapes_positions_velocities() only raises an Exception if
     the shapes of the positions and velocities are not (N, 2) or if the lengths
@@ -147,5 +171,7 @@ def test_check_shapes_positions_velocities_raises_error(kwargs, expected_error):
     if expected_error is None:
         check_shapes_positions_velocities(**kwargs)
     else:
-        with pytest.raises(expected_error):
+        with pytest.raises(expected_error) as excinfo:
             check_shapes_positions_velocities(**kwargs)
+        msg, = excinfo.value.args
+        assert msg == expected_err_msg


### PR DESCRIPTION
while writing tests for `pymovements.utils.paths` I've realized that we have specific error message. I think we should test those within our test coverage.