### PR TITLE
Paths: Get rid of unreachable code in match_filepaths

### DIFF
--- a/src/pymovements/utils/paths.py
+++ b/src/pymovements/utils/paths.py
@@ -131,9 +131,7 @@ def match_filepaths(
 
                 filepath = childpath
                 if relative:
-                    if relative_anchor is None:
-                        relative_anchor = path
-                    filepath = filepath.relative_to(relative_anchor)
+                    filepath = filepath.relative_to(relative_anchor)  # type: ignore[arg-type]
 
                 match_dict['filepath'] = str(filepath)
                 match_dicts.append(match_dict)


### PR DESCRIPTION
## Description

So this one is a bit weird.
Either we have an unreachable path or mypy complains.

I have removed the unreachable path to get 100% coverage and added an ignore instruction for the particular code line.

## Details
mypy doesn't seem to get that the relative anchor cannot be None anymore as we check this already in L116.
It seems to be confused that the condition is in conjunction with `relative`, because it works without (but then the functions doesn't work as expected). 