### PR TITLE
CI: automatically add `from __future__ import annotations`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,14 @@ repos:
     rev: v3.9.0
     hooks:
     -   id: reorder-python-imports
-        args: [--application-directories=src]
+        args: [--application-directories=src, --py37-plus]
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.9.0
+    hooks:
+    -   id: reorder-python-imports
+        files: ^src/
+        exclude: __init__.py
+        args: [--application-directories=src, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/pappasam/toml-sort
     rev: v0.22.4
     hooks:

--- a/src/pymovements/utils/decorators.py
+++ b/src/pymovements/utils/decorators.py
@@ -20,6 +20,8 @@
 """
 This module holds utils for developers and is not part of the user API.
 """
+from __future__ import annotations
+
 from typing import Any
 
 


### PR DESCRIPTION
limited to src and not init files

fixes #280