### PR TITLE
Dataset: don't download in init() but implicitly extract in download()

### DIFF
--- a/docs/source/tutorials/R-tutorial.md
+++ b/docs/source/tutorials/R-tutorial.md
@@ -27,9 +27,15 @@ Access functions and data within python modules and classes via the `$` operator
 To test, you can proceed with the "pymovements in 10 minutes" tutorial,
 for example this is how you download the ToyDataset:
 ```r
-dataset = pm$datasets$ToyDataset(root='testdata', download=TRUE)
+dataset = pm$datasets$ToyDataset(root='data_directory')
+dataset$download()
 ```
 
+Now let's load in the dataset into R and display the found files:
+```r
+dataset$load()
+dataset$fileinfo
+```
 
 
 #### Related handy functions:

--- a/docs/source/tutorials/detecting-events.ipynb
+++ b/docs/source/tutorials/detecting-events.ipynb
@@ -52,7 +52,7 @@
    "id": "532d4aa6",
    "metadata": {},
    "source": [
-    "Let's start by downloading and extracting our `ToyDataset`:"
+    "Let's start by downloading our `ToyDataset` and loading in its data:"
    ]
   },
   {
@@ -64,7 +64,6 @@
    "source": [
     "dataset = pm.datasets.ToyDataset(root='data/')\n",
     "dataset.download()\n",
-    "dataset.extract()\n",
     "dataset.load()"
    ]
   },

--- a/docs/source/tutorials/event-properties.ipynb
+++ b/docs/source/tutorials/event-properties.ipynb
@@ -49,7 +49,7 @@
    "id": "532d4aa6",
    "metadata": {},
    "source": [
-    "Let's start by downloading and extracting our `ToyDataset`:"
+    "Let's start by downloading our `ToyDataset` and loading in its data:"
    ]
   },
   {
@@ -61,7 +61,6 @@
    "source": [
     "dataset = pm.datasets.ToyDataset(root='data/')\n",
     "dataset.download()\n",
-    "dataset.extract()\n",
     "dataset.load()"
    ]
   },

--- a/docs/source/tutorials/heatmap.ipynb
+++ b/docs/source/tutorials/heatmap.ipynb
@@ -10,6 +10,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preparations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We import `pymovements` as the alias `pm` for convenience."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -24,7 +38,7 @@
    "source": [
     "## Loading the Dataset\n",
     "\n",
-    "For demonstration purposes, we will use the `ToyDataset` from `pymovements.datasets`."
+    "Let's start by downloading our `ToyDataset` and loading in its data:"
    ]
   },
   {
@@ -33,13 +47,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load Data\n",
-    "dataset = pm.datasets.ToyDataset(\n",
-    "    root='data/',\n",
-    "    download=True,\n",
-    "    extract=True,\n",
-    "    remove_finished=True,\n",
-    ")"
+    "dataset = pm.datasets.ToyDataset(root='data/')\n",
+    "dataset.download()\n",
+    "dataset.load()"
    ]
   },
   {
@@ -55,7 +65,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset.load()\n",
     "dataset.pix2deg()"
    ]
   },
@@ -166,16 +175,16 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/source/tutorials/local-dataset.ipynb
+++ b/docs/source/tutorials/local-dataset.ipynb
@@ -18,10 +18,46 @@
   },
   {
    "cell_type": "markdown",
+   "id": "15ff8a0c",
+   "metadata": {},
+   "source": [
+    "## Preparations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a01fa671",
+   "metadata": {},
+   "source": [
+    "We import `pymovements` as the alias `pm` for convenience."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25f67fb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pymovements as pm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "92ac248d",
    "metadata": {},
    "source": [
-    "For demonstration purposes, we will use the raw data provided by the Toy dataset, a sample dataset that comes with pymovements."
+    "For demonstration purposes, we will use the raw data provided by the Toy dataset, a sample dataset that comes with *pymovements*.\n",
+    "\n",
+    "We will download the resources of this dataset the directory to simulate a local dataset for you.\n",
+    "All downloaded archive files are automatically extracted and then removed.\n",
+    "The directory of the dataset will be `data/ToyDataset`.\n",
+    "\n",
+    "After that we won't use the python class anymore and delete the object\n",
+    "(the files on your system will stay in place).\n",
+    "Don't worry if you're confused about these lines as they are not relevant to your use case.\n",
+    "\n",
+    "Just keep in mind that we now have some files with gaze data in the directory `data/ToyDataset`."
    ]
   },
   {
@@ -31,14 +67,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pymovements as pm\n",
+    "toy_dataset = pm.datasets.ToyDataset(root='data/')\n",
+    "toy_dataset.download(remove_finished=True)\n",
     "\n",
-    "toy_dataset = pm.datasets.ToyDataset(\n",
-    "    root='data/',\n",
-    "    download=True,\n",
-    "    extract=True,\n",
-    "    remove_finished=True,\n",
-    ")"
+    "del toy_dataset"
    ]
   },
   {
@@ -314,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/plot-main-sequence.ipynb
+++ b/docs/source/tutorials/plot-main-sequence.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, you have to define your dataset. You can already download and extract all the files."
+    "Let's start by downloading our `ToyDataset` and loading in its data:"
    ]
   },
   {
@@ -55,8 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = pm.datasets.toy_dataset.ToyDataset(\n",
-    "    root='data/', download=True, extract=True, remove_finished=True)\n",
+    "dataset = pm.datasets.toy_dataset.ToyDataset(root='data/')\n",
+    "dataset.download()\n",
     "dataset.load()"
    ]
   },

--- a/docs/source/tutorials/preprocessing-raw-data.ipynb
+++ b/docs/source/tutorials/preprocessing-raw-data.ipynb
@@ -50,7 +50,7 @@
    "id": "2169ec44",
    "metadata": {},
    "source": [
-    "Let's start by downloading and extracting our `ToyDataset`:"
+    "Let's start by downloading our `ToyDataset` and loading in its data:"
    ]
   },
   {
@@ -62,7 +62,6 @@
    "source": [
     "dataset = pm.datasets.ToyDataset(root='data/')\n",
     "dataset.download()\n",
-    "dataset.extract()\n",
     "dataset.load()"
    ]
   },

--- a/docs/source/tutorials/public-datasets.ipynb
+++ b/docs/source/tutorials/public-datasets.ipynb
@@ -173,36 +173,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b732b465",
+   "id": "8310fc82",
    "metadata": {},
    "source": [
-    "## Extracting"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e91345c0",
-   "metadata": {},
-   "source": [
-    "You can then extract you downloaded data by calling:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "244859b2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset.extract()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b573a28d",
-   "metadata": {},
-   "source": [
-    "Your data is now extracted to the following directory:"
+    "By default, all archives are recursively extracted to the `raw_rootpath`:"
    ]
   },
   {
@@ -213,6 +187,42 @@
    "outputs": [],
    "source": [
     "dataset.raw_rootpath"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f93ef98",
+   "metadata": {},
+   "source": [
+    "If you want to remove the downloaded archives after extraction to save some space, you can set `remove_finished` to `True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dda16489",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.extract(remove_finished=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1f2e1a8",
+   "metadata": {},
+   "source": [
+    "This is also available for the `PublicDataset.download()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0afffa82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.download(remove_finished=True)"
    ]
   },
   {
@@ -228,7 +238,9 @@
    "id": "1f07d791",
    "metadata": {},
    "source": [
-    "Finally we can load the data into our working memory by using the common `load()` method:"
+    "The `PublicDataset` class is a subset of the `Dataset` class and thus inherits all its functionality.\n",
+    "\n",
+    "Hende, we can load the data into our working memory by using the common `load()` method:"
    ]
   },
   {
@@ -264,7 +276,7 @@
    "id": "8f8d46dd",
    "metadata": {},
    "source": [
-    "Wonderful, all of our data has been downloaded successfully!"
+    "Wonderful, all of our data has been downloaded and loaded in successfully!"
    ]
   },
   {

--- a/docs/source/tutorials/pymovements-in-10-minutes.ipynb
+++ b/docs/source/tutorials/pymovements-in-10-minutes.ipynb
@@ -87,8 +87,25 @@
    "outputs": [],
    "source": [
     "dataset = pm.datasets.ToyDataset(root='data/')\n",
-    "dataset.download()\n",
-    "dataset.extract()"
+    "dataset.download()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b82bcfe3",
+   "metadata": {},
+   "source": [
+    "Archive files are automatically extracted into the `dataset.raw_rootpath`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d897514",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.raw_rootpath"
    ]
   },
   {

--- a/docs/source/tutorials/saving-loading-events.ipynb
+++ b/docs/source/tutorials/saving-loading-events.ipynb
@@ -50,7 +50,7 @@
    "id": "26acca82",
    "metadata": {},
    "source": [
-    "Let's start by downloading and extracting our `ToyDataset`:"
+    "Let's start by downloading our `ToyDataset` and loading in its data:"
    ]
   },
   {
@@ -62,7 +62,7 @@
    "source": [
     "dataset = pm.datasets.ToyDataset(root='data/')\n",
     "dataset.download()\n",
-    "dataset.extract()"
+    "dataset.load()"
    ]
   },
   {
@@ -70,7 +70,7 @@
    "id": "e1cfa35f",
    "metadata": {},
    "source": [
-    "Now let's load in the data and do some preprocessing:"
+    "Now let's do some preprocessing:"
    ]
   },
   {
@@ -80,7 +80,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset.load()\n",
     "dataset.pix2deg()\n",
     "dataset.pos2vel()\n",
     "\n",

--- a/docs/source/tutorials/saving-loading-preprocessed.ipynb
+++ b/docs/source/tutorials/saving-loading-preprocessed.ipynb
@@ -50,7 +50,7 @@
    "id": "26acca82",
    "metadata": {},
    "source": [
-    "Let's start by downloading and extracting our `ToyDataset`:"
+    "Let's start by downloading our `ToyDataset` and loading in its data:"
    ]
   },
   {
@@ -62,7 +62,7 @@
    "source": [
     "dataset = pm.datasets.ToyDataset(root='data/')\n",
     "dataset.download()\n",
-    "dataset.extract()"
+    "dataset.load()"
    ]
   },
   {
@@ -80,7 +80,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset.load()\n",
     "dataset.pix2deg()\n",
     "dataset.pos2vel()\n",
     "\n",

--- a/src/pymovements/datasets/gazebase.py
+++ b/src/pymovements/datasets/gazebase.py
@@ -43,14 +43,14 @@ class GazeBase(PublicDataset):
 
     Check the respective paper for details :cite:p:`GazeBase`.
 
-    Change to ``download=True`` and ``extract=True`` for downloading and extracting the dataset.
+    Examples
+    --------
 
-    >>> dataset = GazeBase(
-    ...     root='data/',
-    ...     download=False,
-    ...     extract=False,
-    ...     remove_finished=False,
-    ... )
+    This will initialize your :py:class:`pymovements.PublicDataset` object, download its resources
+    and load the data into memory.
+
+    >>> dataset = GazeBase(root='data/')
+    >>> dataset.download()  # doctest: +SKIP
     >>> dataset.load()  # doctest: +SKIP
     """
     # pylint: disable=similarities
@@ -107,9 +107,6 @@ class GazeBase(PublicDataset):
     def __init__(
             self,
             root: str | Path,
-            download: bool = False,
-            extract: bool = False,
-            remove_finished: bool = False,
             dataset_dirname: str = 'GazeBase',
             downloads_dirname: str = 'downloads',
             raw_dirname: str = 'raw',
@@ -135,12 +132,6 @@ class GazeBase(PublicDataset):
         ----------
         root : str, Path
             Path to the root directory of the dataset.
-        download : bool
-            Download all dataset resources.
-        extract : bool
-            Extract dataset archive files.
-        remove_finished : bool
-            Remove archive files after extraction.
         dataset_dirname : str, optional
             Dataset directory name under root path. Can be `.` if dataset is located in root path.
             Default: `.`
@@ -160,9 +151,6 @@ class GazeBase(PublicDataset):
         """
         super().__init__(
             root=root,
-            download=download,
-            extract=extract,
-            remove_finished=remove_finished,
             experiment=self._experiment,
             filename_regex=self._filename_regex,
             filename_regex_dtypes=self._filename_regex_dtypes,

--- a/src/pymovements/datasets/judo1000.py
+++ b/src/pymovements/datasets/judo1000.py
@@ -39,14 +39,11 @@ class JuDo1000(PublicDataset):
 
     Examples
     --------
-    Change to ``download=True`` and ``extract=True`` for downloading and extracting the dataset.
+    This will initialize your :py:class:`pymovements.PublicDataset` object, download its resources
+    and load the data into memory.
 
-    >>> dataset = JuDo1000(
-    ...     root='data/',
-    ...     download=False,
-    ...     extract=False,
-    ...     remove_finished=False,
-    ... )
+    >>> dataset = JuDo1000(root='data/')
+    >>> dataset.download()  # doctest: +SKIP
     >>> dataset.load()  # doctest: +SKIP
     """
     # pylint: disable=similarities
@@ -100,9 +97,6 @@ class JuDo1000(PublicDataset):
     def __init__(
             self,
             root: str | Path,
-            download: bool = False,
-            extract: bool = False,
-            remove_finished: bool = False,
             dataset_dirname: str = 'JuDo1000',
             downloads_dirname: str = 'downloads',
             raw_dirname: str = 'raw',
@@ -128,12 +122,6 @@ class JuDo1000(PublicDataset):
         ----------
         root : str, Path
             Path to the root directory of the dataset.
-        download : bool
-            Download all dataset resources.
-        extract : bool
-            Extract dataset archive files.
-        remove_finished : bool
-            Remove archive files after extraction.
         dataset_dirname : str, optional
             Dataset directory name under root path. Can be `.` if dataset is located in root path.
             Default: `.`
@@ -153,9 +141,6 @@ class JuDo1000(PublicDataset):
         """
         super().__init__(
             root=root,
-            download=download,
-            extract=extract,
-            remove_finished=remove_finished,
             experiment=self._experiment,
             filename_regex=self._filename_regex,
             filename_regex_dtypes=self._filename_regex_dtypes,

--- a/src/pymovements/datasets/toy_dataset.py
+++ b/src/pymovements/datasets/toy_dataset.py
@@ -37,14 +37,11 @@ class ToyDataset(PublicDataset):
 
     Examples
     --------
-    Change to ``download=True`` and ``extract=True`` for downloading and extracting the dataset.
+    This will initialize your :py:class:`pymovements.PublicDataset` object, download its resources
+    and load the data into memory.
 
-    >>> dataset = ToyDataset(
-    ...     root='data/',
-    ...     download=False,
-    ...     extract=False,
-    ...     remove_finished=False,
-    ... )
+    >>> dataset = ToyDataset(root='data/')
+    >>> dataset.download()  # doctest: +SKIP
     >>> dataset.load()  # doctest: +SKIP
     """
     # pylint: disable=similarities
@@ -95,9 +92,6 @@ class ToyDataset(PublicDataset):
     def __init__(
             self,
             root: str | Path,
-            download: bool = False,
-            extract: bool = False,
-            remove_finished: bool = False,
             dataset_dirname: str = 'ToyDataset',
             downloads_dirname: str = 'downloads',
             raw_dirname: str = 'raw',
@@ -123,12 +117,6 @@ class ToyDataset(PublicDataset):
         ----------
         root : str, Path
             Path to the root directory of the dataset.
-        download : bool
-            Download all dataset resources.
-        extract : bool
-            Extract dataset archive files.
-        remove_finished : bool
-            Remove archive files after extraction.
         dataset_dirname : str, optional
             Dataset directory name under root path. Can be `.` if dataset is located in root path.
             Default: `.`
@@ -148,9 +136,6 @@ class ToyDataset(PublicDataset):
         """
         super().__init__(
             root=root,
-            download=download,
-            extract=extract,
-            remove_finished=remove_finished,
             experiment=self._experiment,
             filename_regex=self._filename_regex,
             filename_regex_dtypes=self._filename_regex_dtypes,

--- a/tests/datasets/public_dataset_test.py
+++ b/tests/datasets/public_dataset_test.py
@@ -135,10 +135,10 @@ def test_dataset_download_file_not_found(mock_download_file, tmp_path, dataset):
 
 
 @mock.patch('pymovements.datasets.public_dataset.download_file')
-def test_dataset_download(mock_download_file, tmp_path, dataset):
+def test_dataset_download_no_extract(mock_download_file, tmp_path, dataset):
     mock_download_file.return_value = 'path'
 
-    dataset.download()
+    dataset.download(extract=False)
 
     mock_download_file.assert_has_calls([
         mock.call(
@@ -190,9 +190,9 @@ def test_dataset_extract_remove_finished_false(
     ])
 
 
-@mock.patch('pymovements.datasets.public_dataset.PublicDataset.download')
-@mock.patch('pymovements.datasets.public_dataset.PublicDataset.extract')
-def test_custom_dataset_download_extract(mock_extract, mock_download, tmp_path):
+@mock.patch('pymovements.datasets.public_dataset.download_file')
+@mock.patch('pymovements.datasets.public_dataset.extract_archive')
+def test_custom_dataset_download_default_extract(mock_extract, mock_download, tmp_path):
     mock_extract.return_value = None
     mock_download.return_value = None
 
@@ -206,8 +206,7 @@ def test_custom_dataset_download_extract(mock_extract, mock_download, tmp_path):
             },
         ]
 
-    CustomPublicDataset(root=tmp_path, download=True)
-    CustomPublicDataset(root=tmp_path, extract=True)
+    CustomPublicDataset(root=tmp_path).download()
 
     mock_download.assert_called_once()
     mock_extract.assert_called_once()


### PR DESCRIPTION
## Description

This PR removes the download and extract parameters from the initialization of the `PublicDataset` class.
Instead, the user is expected to call `PublicDataset.download()` explicitly. Extracting is done implicitly in this call.

At first this might seem odd as we might already be comfortable how public datasets are downloaded.

But the way it was implemented was rather bad practice, as a constructor is not supposed to do much more than just initializing your object.
That's why `download` was set to `False` per default in `PublicDataset.__init__()`.

Now we have a much more separated responsibilities in the methods:

`PublicDataset.__init__()` initializes your dataset object without any unexpected downloads.

`PublicDataset.download()` downloads and extracts your dataset.

Using `PublicDataset.download(extract=False)` you can disable this.

Using `PublicDataset.download(remove_finished=True` you can remove the original archive files.


And just for comparison to see that now it's also much cleaner from user perspective:

New:
```python
dataset = ToyDataset(root='data')
dataset.download(remove_finished=True)
```

Old:
```python
dataset = ToyDataset(
    root='data',
    download=True,
    remove_finished=True,
)
```

As `download()` now also returns a referrence to `self` we can even to that:
```python
dataset = ToyDataset(root='data').download(remove_finished=True)
```


## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] Removed download and extract behavior from `init()`
- [x] add `extract` and `remove_finished` argument to `download()`
- [x] Updated examples accordingly
- [x] Updates all tutorials accordingly

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change is or requires a documentation update

## How Has This Been Tested?

Two tests were slightly adjusted:

- [x] `test_dataset_download` -> `test_dataset_download_no_extract` by setting `download(extract=False)`
- [x] `test_custom_dataset_download_extract` -> `test_custom_dataset_download_extract` by checking that `download()` also extracts by default

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
