### PR TITLE
CI: Check types more thoroughly with mypy (#295)

### DIFF
--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,12 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 check_untyped_defs = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "docs.*"
+check_untyped_defs = false
+disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 addopts = "-ra -l -v --doctest-modules"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,13 @@ omit = [
 [tool.doc8]
 max-line-length = 100
 
+[tool.mypy]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
 [[tool.mypy.overrides]]
 module = "scipy.*"
 ignore_missing_imports = true
@@ -112,6 +119,10 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "matplotlib.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+check_untyped_defs = false
 
 [tool.pytest.ini_options]
 addopts = "-ra -l -v --doctest-modules"

--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 from tqdm.auto import tqdm
@@ -264,7 +265,7 @@ class Dataset:
 
         return self
 
-    def pos2vel(self, method: str = 'smooth', verbose: bool = True, **kwargs) -> Dataset:
+    def pos2vel(self, method: str = 'smooth', verbose: bool = True, **kwargs: Any) -> Dataset:
         """Compute gaze velocites in dva/s from dva coordinates.
 
         This method requires a properly initialized :py:attr:`~.Dataset.experiment` attribute.
@@ -305,7 +306,7 @@ class Dataset:
             eye: str | None = 'auto',
             clear: bool = False,
             verbose: bool = True,
-            **kwargs,
+            **kwargs: Any,
     ) -> Dataset:
         """Detect events by applying a specific event detection method.
 

--- a/src/pymovements/dataset/dataset_definition.py
+++ b/src/pymovements/dataset/dataset_definition.py
@@ -78,7 +78,7 @@ class DatasetDefinition:
 
     column_map: dict[str, str] = field(default_factory=dict)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if len(self.column_map) > 0:
             self.custom_read_kwargs['columns'] = list(self.column_map.keys())
             self.custom_read_kwargs['new_columns'] = list(self.column_map.values())

--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -125,7 +125,7 @@ class EventDataFrame:
     def __len__(self) -> int:
         return self.frame.__len__()
 
-    def __getitem__(self, *args, **kwargs) -> Any:
+    def __getitem__(self, *args: str, **kwargs: str) -> Any:
         return self.frame.__getitem__(*args, **kwargs)
 
     @property
@@ -133,7 +133,7 @@ class EventDataFrame:
         """List of column names."""
         return self.frame.columns
 
-    def _add_duration_property(self):
+    def _add_duration_property(self) -> None:
         """Adds duration property column to dataframe."""
         self.frame = self.frame.select([pl.all(), duration().alias('duration')])
 
@@ -179,7 +179,7 @@ class EventDetectionCallable(Protocol):
             velocities: list[list[float]] | list[tuple[float, float]] | np.ndarray,
             timesteps: list[int] | np.ndarray | None = None,
             minimum_duration: int = 0,
-            **kwargs,
+            **kwargs: int | str | float,
     ) -> EventDataFrame:
         """Minimal interface to be implemented by all event detection methods.
 

--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -88,7 +88,10 @@ class EventDataFrame:
 
             # Make sure lengths of onsets and offsets are equal.
             if onsets is not None:
+
+                # mypy does not get that offsets cannot be None (l. 87)
                 assert offsets is not None
+
                 checks.check_is_length_matching(onsets=onsets, offsets=offsets)
                 # In case name is given as a list, check that too.
                 if isinstance(name, Sequence) and not isinstance(name, str):

--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -125,7 +125,7 @@ class EventDataFrame:
     def __len__(self) -> int:
         return self.frame.__len__()
 
-    def __getitem__(self, *args: str, **kwargs: str) -> Any:
+    def __getitem__(self, *args: Any, **kwargs: Any) -> Any:
         return self.frame.__getitem__(*args, **kwargs)
 
     @property

--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -88,6 +88,7 @@ class EventDataFrame:
 
             # Make sure lengths of onsets and offsets are equal.
             if onsets is not None:
+                assert offsets is not None
                 checks.check_is_length_matching(onsets=onsets, offsets=offsets)
                 # In case name is given as a list, check that too.
                 if isinstance(name, Sequence) and not isinstance(name, str):

--- a/src/pymovements/gaze/experiment.py
+++ b/src/pymovements/gaze/experiment.py
@@ -98,7 +98,7 @@ class Experiment:
             self,
             arr: list[float] | list[list[float]] | np.ndarray,
             method: str = 'smooth',
-            **kwargs,
+            **kwargs: int | float | str,
     ) -> np.ndarray:
         """Compute velocity time series from 2-dimensional position time series.
 

--- a/src/pymovements/gaze/gaze_dataframe.py
+++ b/src/pymovements/gaze/gaze_dataframe.py
@@ -107,7 +107,7 @@ class GazeDataFrame:
             ],
         )
 
-    def pos2vel(self, method: str = 'smooth', **kwargs) -> None:
+    def pos2vel(self, method: str = 'smooth', **kwargs: int | float | str) -> None:
         """Compute gaze velocites in dva/s from dva position coordinates.
 
         This method requires a properly initialized :py:attr:`~.GazeDataFrame.experiment` attribute.

--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -165,7 +165,7 @@ def pos2vel(
         arr: list[float] | list[list[float]] | np.ndarray,
         sampling_rate: float = 1000,
         method: str = 'smooth',
-        **kwargs,
+        **kwargs: int | float | str,
 ) -> np.ndarray:
     """Compute velocity time series from 2-dimensional position time series.
 

--- a/src/pymovements/plotting/heatmap.py
+++ b/src/pymovements/plotting/heatmap.py
@@ -32,7 +32,7 @@ from pymovements.gaze import GazeDataFrame
 def heatmap(
     gaze: GazeDataFrame,
     position_columns: tuple[str, str] = ('x_pix', 'y_pix'),
-    gridsize=(10, 10),
+    gridsize: tuple[int, int] = (10, 10),
     cmap: colors.Colormap | str = 'jet',
     interpolation: str = 'gaussian',
     origin: str = 'lower',

--- a/src/pymovements/utils/checks.py
+++ b/src/pymovements/utils/checks.py
@@ -23,9 +23,9 @@ This module holds basic checks which will be reused in other modules.
 from __future__ import annotations
 
 from typing import Any
+from typing import Sized
 
 import numpy as np
-import polars as pl
 
 
 def check_no_zeros(variable: Any, name: str = 'variable') -> None:
@@ -95,9 +95,7 @@ def check_shapes_positions_velocities(positions: np.ndarray, velocities: np.ndar
         )
 
 
-def check_two_kwargs(
-        **kwargs: Any,
-) -> None:
+def check_two_kwargs(**kwargs: Any) -> None:
     """Check if exactly two keyword arguments are given.
 
     Parameters
@@ -114,9 +112,7 @@ def check_two_kwargs(
         raise ValueError('there must be exactly two keyword arguments in kwargs')
 
 
-def check_is_mutual_exclusive(
-        **kwargs: None | str | list[str] | list[int] | np.ndarray | pl.DataFrame,
-) -> None:
+def check_is_mutual_exclusive(**kwargs: Any) -> None:
     """Check if at most one of two values is not None.
 
     Parameters
@@ -142,9 +138,7 @@ def check_is_mutual_exclusive(
         )
 
 
-def check_is_none_is_mutual(
-        **kwargs: None | list[int] | np.ndarray,
-) -> None:
+def check_is_none_is_mutual(**kwargs: Any) -> None:
     """Check if two values are either both None or both have a value.
 
     Parameters
@@ -171,10 +165,7 @@ def check_is_none_is_mutual(
         )
 
 
-def check_is_length_matching(
-        **kwargs: np.ndarray | list[list[float]] | list[tuple[float, float]] |
-        list[str] | list[int] | None,
-) -> None:
+def check_is_length_matching(**kwargs: Sized) -> None:
     """Check if two sequences are of equal length.
 
     Parameters
@@ -192,11 +183,6 @@ def check_is_length_matching(
     key_1, key_2 = (key for _, key in zip(range(2), kwargs.keys()))
     value_1 = kwargs[key_1]
     value_2 = kwargs[key_2]
-
-    # mypy does not understand value_1 and value_2 can't be None
-    # see pymovements.events.detection.* for specific checks
-    assert value_1 is not None
-    assert value_2 is not None
 
     if not len(value_1) == len(value_2):
         raise ValueError(f'The sequences "{key_1}" and "{key_2}" must be of equal length.')

--- a/src/pymovements/utils/checks.py
+++ b/src/pymovements/utils/checks.py
@@ -22,8 +22,8 @@ This module holds basic checks which will be reused in other modules.
 """
 from __future__ import annotations
 
+from collections.abc import Sized
 from typing import Any
-from typing import Sized
 
 import numpy as np
 

--- a/src/pymovements/utils/checks.py
+++ b/src/pymovements/utils/checks.py
@@ -137,7 +137,9 @@ def check_is_mutual_exclusive(**kwargs) -> None:
         )
 
 
-def check_is_none_is_mutual(**kwargs) -> None:
+def check_is_none_is_mutual(
+    **kwargs: None,
+) -> None:
     """Check if two values are either both None or both have a value.
 
     Parameters
@@ -164,7 +166,9 @@ def check_is_none_is_mutual(**kwargs) -> None:
         )
 
 
-def check_is_length_matching(**kwargs) -> None:
+def check_is_length_matching(
+        **kwargs: np.ndarray | list[list[float]] | list[tuple[float, float]] | list[str] | list[int] | None,
+) -> None:
     """Check if two sequences are of equal length.
 
     Parameters
@@ -182,6 +186,11 @@ def check_is_length_matching(**kwargs) -> None:
     key_1, key_2 = (key for _, key in zip(range(2), kwargs.keys()))
     value_1 = kwargs[key_1]
     value_2 = kwargs[key_2]
+
+    # mypy does not understand value_1 and value_2 can't be None
+    # see pymovements.events.detection.* for specific checks
+    assert value_1 is not None
+    assert value_2 is not None
 
     if not len(value_1) == len(value_2):
         raise ValueError(f'The sequences "{key_1}" and "{key_2}" must be of equal length.')

--- a/src/pymovements/utils/checks.py
+++ b/src/pymovements/utils/checks.py
@@ -95,7 +95,9 @@ def check_shapes_positions_velocities(positions: np.ndarray, velocities: np.ndar
         )
 
 
-def check_two_kwargs(**kwargs) -> None:
+def check_two_kwargs(
+        **kwargs: Any,
+) -> None:
     """Check if exactly two keyword arguments are given.
 
     Parameters

--- a/src/pymovements/utils/checks.py
+++ b/src/pymovements/utils/checks.py
@@ -138,7 +138,7 @@ def check_is_mutual_exclusive(**kwargs) -> None:
 
 
 def check_is_none_is_mutual(
-    **kwargs: None,
+    **kwargs: None | list[int] | np.ndarray,
 ) -> None:
     """Check if two values are either both None or both have a value.
 

--- a/src/pymovements/utils/checks.py
+++ b/src/pymovements/utils/checks.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import polars as pl
 
 
 def check_no_zeros(variable: Any, name: str = 'variable') -> None:
@@ -111,7 +112,9 @@ def check_two_kwargs(**kwargs) -> None:
         raise ValueError('there must be exactly two keyword arguments in kwargs')
 
 
-def check_is_mutual_exclusive(**kwargs) -> None:
+def check_is_mutual_exclusive(
+        **kwargs: None | str | list[str] | list[int] | np.ndarray | pl.DataFrame,
+) -> None:
     """Check if at most one of two values is not None.
 
     Parameters
@@ -138,7 +141,7 @@ def check_is_mutual_exclusive(**kwargs) -> None:
 
 
 def check_is_none_is_mutual(
-    **kwargs: None | list[int] | np.ndarray,
+        **kwargs: None | list[int] | np.ndarray,
 ) -> None:
     """Check if two values are either both None or both have a value.
 

--- a/src/pymovements/utils/checks.py
+++ b/src/pymovements/utils/checks.py
@@ -172,7 +172,8 @@ def check_is_none_is_mutual(
 
 
 def check_is_length_matching(
-        **kwargs: np.ndarray | list[list[float]] | list[tuple[float, float]] | list[str] | list[int] | None,
+        **kwargs: np.ndarray | list[list[float]] | list[tuple[float, float]] |
+        list[str] | list[int] | None,
 ) -> None:
     """Check if two sequences are of equal length.
 

--- a/src/pymovements/utils/decorators.py
+++ b/src/pymovements/utils/decorators.py
@@ -23,9 +23,12 @@ This module holds utils for developers and is not part of the user API.
 from __future__ import annotations
 
 from typing import Any
+from typing import TypeVar
+
+ClassT = TypeVar('ClassT')
 
 
-def auto_str(cls: Any) -> str:
+def auto_str(cls: type[ClassT]) -> type[ClassT]:
     """
     Automatically generate __str__() to include all arguments. Can be used as a decorator.
     """
@@ -38,5 +41,6 @@ def auto_str(cls: Any) -> str:
         attributes = ', '.join(f'{key}={shorten(value)}' for key, value in vars(self).items())
         return f'{type(self).__name__}({attributes})'
 
-    cls.__str__ = __str__
+    # for type ignore see: https://github.com/python/mypy/issues/3951#issuecomment-329183108
+    cls.__str__ = __str__  # type: ignore
     return cls

--- a/src/pymovements/utils/decorators.py
+++ b/src/pymovements/utils/decorators.py
@@ -25,16 +25,16 @@ from __future__ import annotations
 from typing import Any
 
 
-def auto_str(cls):
+def auto_str(cls: Any) -> str:
     """
     Automatically generate __str__() to include all arguments. Can be used as a decorator.
     """
-    def shorten(value: Any):
+    def shorten(value: Any) -> str:
         if isinstance(value, float):
             value = f'{value:.2f}'
         return value
 
-    def __str__(self):
+    def __str__(self: Any) -> str:
         attributes = ', '.join(f'{key}={shorten(value)}' for key, value in vars(self).items())
         return f'{type(self).__name__}({attributes})'
 

--- a/src/pymovements/utils/downloads.py
+++ b/src/pymovements/utils/downloads.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import hashlib
 import urllib.request
 from pathlib import Path
+from typing import Any
 
 from tqdm.auto import tqdm
 
@@ -200,7 +201,7 @@ class _DownloadProgressBar(tqdm):  # pylint: disable=inconsistent-mro
     def __init__(self, **kwargs: Any):
         super().__init__(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, **kwargs)
 
-    def update_to(self, b: int | None = 1, bsize int | None = 1, tsize None | int = None) -> int:
+    def update_to(self, b: int = 1, bsize: int = 1, tsize: None | int = None) -> bool | None:
         """
         b  : int, optional
             Number of blocks transferred so far [default: 1].

--- a/src/pymovements/utils/downloads.py
+++ b/src/pymovements/utils/downloads.py
@@ -197,10 +197,10 @@ class _DownloadProgressBar(tqdm):  # pylint: disable=inconsistent-mro
     Reference: https://github.com/tqdm/tqdm#hooks-and-callbacks
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         super().__init__(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, **kwargs)
 
-    def update_to(self, b=1, bsize=1, tsize=None):
+    def update_to(self, b: int | None = 1, bsize int | None = 1, tsize None | int = None) -> int:
         """
         b  : int, optional
             Number of blocks transferred so far [default: 1].
@@ -214,7 +214,7 @@ class _DownloadProgressBar(tqdm):  # pylint: disable=inconsistent-mro
         return self.update(b * bsize - self.n)  # also sets self.n = b * bsize
 
 
-def _download_url(url: str, destination: Path):
+def _download_url(url: str, destination: Path) -> None:
     """Download file from URL and save to destination.
 
     Parameters

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.


### PR DESCRIPTION
ass discussed in PR #293 we add 

```toml
[tools.mypy]
check_untyped_defs = true
disallow_any_generics = true
disallow_incomplete_defs = true
disallow_untyped_defs = true
warn_redundant_casts = true
warn_unused_ignores = true
```

to pyproject.toml. 

all code was adjusted accordingly. in some places I didn't figure out what exactly the type is and had to insert Any -- might change this later