### PR TITLE
Tests: Close figures after testing plot functions.

### DIFF
--- a/tests/plotting/heatmap_test.py
+++ b/tests/plotting/heatmap_test.py
@@ -119,6 +119,7 @@ def test_heatmap_show(args, kwargs, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     heatmap(**args, **kwargs)
+    plt.close()
     mock.assert_called_once()
 
 
@@ -126,6 +127,7 @@ def test_heatmap_noshow(args, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     heatmap(**args, show=False)
+    plt.close()
     mock.assert_not_called()
 
 
@@ -133,6 +135,7 @@ def test_heatmap_save(args, monkeypatch, tmp_path):
     mock = Mock()
     monkeypatch.setattr(figure.Figure, 'savefig', mock)
     heatmap(**args, show=False, savepath=str(tmp_path / 'test.svg'))
+    plt.close()
     mock.assert_called_once()
 
 

--- a/tests/plotting/main_sequence_plot_test.py
+++ b/tests/plotting/main_sequence_plot_test.py
@@ -47,6 +47,7 @@ def test_main_sequence_plot_show_plot(input_df, show, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     main_sequence_plot(input_df, show=show)
+    plt.close()
     mock.assert_called_once()
 
 
@@ -68,6 +69,7 @@ def test_main_sequence_plot_save_path(input_df, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt.Figure, 'savefig', mock)
     main_sequence_plot(input_df, show=False, savepath='mock')
+    plt.close()
     mock.assert_called_once()
 
 
@@ -90,6 +92,7 @@ def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     main_sequence_plot(input_df, show=show)
+    plt.close()
     mock.assert_not_called()
 
 

--- a/tests/plotting/traceplot_test.py
+++ b/tests/plotting/traceplot_test.py
@@ -80,6 +80,7 @@ def test_traceplot_show(args, kwargs, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     traceplot(*args, **kwargs)
+    plt.close()
     mock.assert_called_once()
 
 
@@ -87,6 +88,7 @@ def test_traceplot_noshow(args, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     traceplot(*args, show=False)
+    plt.close()
     mock.assert_not_called()
 
 
@@ -94,6 +96,7 @@ def test_traceplot_save(args, monkeypatch, tmp_path):
     mock = Mock()
     monkeypatch.setattr(figure.Figure, 'savefig', mock)
     traceplot(*args, show=False, savepath=str(tmp_path / 'test.svg'))
+    plt.close()
     mock.assert_called_once()
 
 

--- a/tests/plotting/tsplot_test.py
+++ b/tests/plotting/tsplot_test.py
@@ -54,6 +54,7 @@ def test_tsplot_show(arr, kwargs, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     tsplot(arr, **kwargs)
+    plt.close()
     mock.assert_called_once()
 
 
@@ -61,6 +62,7 @@ def test_tsplot_1d(monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     tsplot(np.arange(-100, 100))
+    plt.close()
     mock.assert_called_once()
 
 
@@ -68,6 +70,7 @@ def test_tsplot_noshow(arr, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(plt, 'show', mock)
     tsplot(arr, show=False)
+    plt.close()
     mock.assert_not_called()
 
 
@@ -75,6 +78,7 @@ def test_tsplot_save(arr, monkeypatch, tmp_path):
     mock = Mock()
     monkeypatch.setattr(figure.Figure, 'savefig', mock)
     tsplot(arr, show=False, savepath=str(tmp_path / 'test.svg'))
+    plt.close()
     mock.assert_called_once()
 
 


### PR DESCRIPTION
## Description

pytest currently throws a warning on my local machine that over 20 plots are open and not closed.
This is because we create new figures for test cases but newer close them.


## Implemented changes

- [x] Call `plt.close()` in each plot test case

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

tests now don't raise any warnings any more. Apart from that I didn't add any tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
