### PR TITLE
Fix main sequence bug

### DIFF
--- a/docs/source/tutorials/plot-main-sequence.ipynb
+++ b/docs/source/tutorials/plot-main-sequence.ipynb
@@ -33,14 +33,9 @@
    "outputs": [],
    "source": [
     "import pymovements as pm\n",
-    "from pymovements.events import microsaccades\n",
+    "from pymovements.events import ivt, microsaccades\n",
     "from pymovements.plotting import main_sequence_plot"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -130,7 +125,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset.detect_events(microsaccades)"
+    "dataset.detect_events(microsaccades)\n",
+    "dataset.detect_events(ivt)"
    ]
   },
   {
@@ -221,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/src/pymovements/plotting/main_sequence_plot.py
+++ b/src/pymovements/plotting/main_sequence_plot.py
@@ -55,10 +55,17 @@ def main_sequence_plot(
     KeyError
         If the input dataframe has no 'amplitude' and/or 'peak_velocity' column.
         Those are needed to create the plot.
+    ValueError
+        If the event dataframe does not contain any saccades.
     """
+    saccades = data.filter(pl.col('name') == 'saccade')
+
+    if saccades.is_empty():
+        raise ValueError('There are no saccades in the event dataframe. '
+                         'Make sure you can the saccades detection algorithm and saved the events.')
 
     try:
-        peak_velocities = data['peak_velocity'].to_list()
+        peak_velocities = saccades['peak_velocity'].to_list()
     except ColumnNotFoundError as exc:
         raise KeyError(
             'The input dataframe you provided does not contain '
@@ -67,7 +74,7 @@ def main_sequence_plot(
         ) from exc
 
     try:
-        amplitudes = data['amplitude'].to_list()
+        amplitudes = saccades['amplitude'].to_list()
     except ColumnNotFoundError as exc:
         raise KeyError(
             'The input dataframe you provided does not contain '

--- a/src/pymovements/plotting/main_sequence_plot.py
+++ b/src/pymovements/plotting/main_sequence_plot.py
@@ -58,11 +58,15 @@ def main_sequence_plot(
     ValueError
         If the event dataframe does not contain any saccades.
     """
-    saccades = data.filter(pl.col('name') == 'saccade')
+    event_col_name = 'name'
+    saccades = data.filter(pl.col(event_col_name) == 'saccade')
 
     if saccades.is_empty():
-        raise ValueError('There are no saccades in the event dataframe. '
-                         'Make sure you can the saccades detection algorithm and saved the events.')
+        raise ValueError(
+            'There are no saccades in the event dataframe. '
+            'Please make sure you ran a saccade detection algorithm. '
+            f'The event name should be stored in a colum called "{event_col_name}".',
+        )
 
     try:
         peak_velocities = saccades['peak_velocity'].to_list()

--- a/tests/plotting/main_sequence_plot_test.py
+++ b/tests/plotting/main_sequence_plot_test.py
@@ -140,7 +140,8 @@ def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
                 },
             ),
             ValueError,
-            'There are no saccades in the event dataframe. Please make sure you ran a saccade detection algorithm. '
+            'There are no saccades in the event dataframe. '
+            'Please make sure you ran a saccade detection algorithm. '
             'The event name should be stored in a colum called "name".',
             id='no_saccades_in_event_df',
         ),

--- a/tests/plotting/main_sequence_plot_test.py
+++ b/tests/plotting/main_sequence_plot_test.py
@@ -46,11 +46,53 @@ from pymovements.plotting.main_sequence_plot import main_sequence_plot
     ],
 )
 def test_main_sequence_plot_show_plot(input_df, show, monkeypatch):
-    mock = Mock()
-    monkeypatch.setattr(plt, 'show', mock)
-    main_sequence_plot(input_df, show=show)
-    plt.close()
-    mock.assert_called_once()
+    mock_show = Mock()
+    mock_scatter = Mock()
+
+    monkeypatch.setattr(plt, 'show', mock_show)
+    monkeypatch.setattr(plt, 'scatter', mock_scatter)
+
+    main_sequence_plot(input_df, show=show, savepath='mock')
+
+    mock_scatter.assert_called_with(
+        [1.0, 1.0, 2.0, 2.0, 3.0, 4.0],
+        [10.0, 11.0, 12.0, 11.0, 13.0, 13.0],
+        color='purple',
+        alpha=0.5,
+    )
+
+    mock_show.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    'input_df',
+    [
+        pytest.param(
+            pl.DataFrame(
+                {
+                    'amplitude': [1.0, 1.0, 2.0, 2.0, 3.0, 4.0],
+                    'peak_velocity': [10.0, 11.0, 12.0, 11.0, 13.0, 13.0],
+                    'name': ['saccade' for _ in range(5)] + ['fixation'],
+
+                },
+            ),
+            id='filter_out_fixations',
+        ),
+    ],
+)
+def test_main_sequence_plot_filter_out_fixations(input_df, monkeypatch):
+    mock_scatter = Mock()
+
+    monkeypatch.setattr(plt, 'scatter', mock_scatter)
+
+    main_sequence_plot(input_df, show=False, savepath='mock')
+
+    mock_scatter.assert_called_with(
+        [1.0, 1.0, 2.0, 2.0, 3.0],
+        [10.0, 11.0, 12.0, 11.0, 13.0],
+        color='purple',
+        alpha=0.5,
+    )
 
 
 @pytest.mark.parametrize(
@@ -70,11 +112,11 @@ def test_main_sequence_plot_show_plot(input_df, show, monkeypatch):
     ],
 )
 def test_main_sequence_plot_save_path(input_df, monkeypatch):
-    mock = Mock()
-    monkeypatch.setattr(plt.Figure, 'savefig', mock)
+    mock_function = Mock()
+    monkeypatch.setattr(plt.Figure, 'savefig', mock_function)
     main_sequence_plot(input_df, show=False, savepath='mock')
     plt.close()
-    mock.assert_called_once()
+    mock_function.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -94,11 +136,11 @@ def test_main_sequence_plot_save_path(input_df, monkeypatch):
     ],
 )
 def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
-    mock = Mock()
-    monkeypatch.setattr(plt, 'show', mock)
+    mock_function = Mock()
+    monkeypatch.setattr(plt, 'show', mock_function)
     main_sequence_plot(input_df, show=show)
     plt.close()
-    mock.assert_not_called()
+    mock_function.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -147,7 +189,7 @@ def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
         ),
     ],
 )
-def test_main_sequence_plot_not_show_plot(input_df, expected_error, error_msg):
+def test_main_sequence_plot_error(input_df, expected_error, error_msg):
     with pytest.raises(expected_error) as actual_error:
         main_sequence_plot(input_df)
 

--- a/tests/plotting/main_sequence_plot_test.py
+++ b/tests/plotting/main_sequence_plot_test.py
@@ -36,6 +36,8 @@ from pymovements.plotting.main_sequence_plot import main_sequence_plot
                 {
                     'amplitude': [1.0, 1.0, 2.0, 2.0, 3.0, 4.0],
                     'peak_velocity': [10.0, 11.0, 12.0, 11.0, 13.0, 13.0],
+                    'name': ['saccade' for _ in range(6)],
+
                 },
             ),
             True,
@@ -59,6 +61,8 @@ def test_main_sequence_plot_show_plot(input_df, show, monkeypatch):
                 {
                     'amplitude': np.arange(100),
                     'peak_velocity': np.linspace(10, 50, num=100),
+                    'name': ['saccade' for _ in range(100)],
+
                 },
             ),
             id='save_path',
@@ -81,6 +85,7 @@ def test_main_sequence_plot_save_path(input_df, monkeypatch):
                 {
                     'amplitude': np.arange(100),
                     'peak_velocity': np.linspace(10, 50, num=100),
+                    'name': ['saccade' for _ in range(100)],
                 },
             ),
             False,
@@ -103,6 +108,8 @@ def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
             pl.DataFrame(
                 {
                     'peak_velocity': np.linspace(10, 50, num=100),
+                    'name': ['saccade' for _ in range(100)],
+
                 },
             ),
             KeyError,
@@ -115,6 +122,7 @@ def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
             pl.DataFrame(
                 {
                     'amplitude': np.arange(100),
+                    'name': ['saccade' for _ in range(100)],
                 },
             ),
             KeyError,
@@ -123,10 +131,21 @@ def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
             'the main sequence plot. ',
             id='peak_velocity_missing',
         ),
+        pytest.param(
+            pl.DataFrame(
+                {
+                    'amplitude': [1.0, 1.0],
+                    'peak_velocity': [10.0, 11.0],
+                    'name': ['fixation', 'fixation'],
+                },
+            ),
+            ValueError,
+            'There are no saccades in the dataframe.',
+            id='no_saccades_in_event_df',
+        ),
     ],
 )
 def test_main_sequence_plot_not_show_plot(input_df, expected_error, error_msg):
-
     with pytest.raises(expected_error) as actual_error:
         main_sequence_plot(input_df)
 

--- a/tests/plotting/main_sequence_plot_test.py
+++ b/tests/plotting/main_sequence_plot_test.py
@@ -140,7 +140,8 @@ def test_main_sequence_plot_not_show(input_df, show, monkeypatch):
                 },
             ),
             ValueError,
-            'There are no saccades in the dataframe.',
+            'There are no saccades in the event dataframe. Please make sure you ran a saccade detection algorithm. '
+            'The event name should be stored in a colum called "name".',
             id='no_saccades_in_event_df',
         ),
     ],


### PR DESCRIPTION
## Description

This PR fixes a bug that would also plot fixations in the saccadic main sequence plot instead of only saccades.

Fixes issue #303 

## Implemented changes

- [ ] filter for saccades
- [ ] throw value error if there are no saccades in the event df

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

- [ ] added 'name' column with saccade events to all existing tests
- [ ] new test where there are no saccades but only fixations in the event df

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
