### PR TITLE
Package: Update polars version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "matplotlib>=3.0.0",
   "numpy>=1.10.0",
   "pandas>1.0.0",
-  "polars>=0.16.13",
+  "polars>=0.17.2",
   "pyarrow>=4.0.0",
   "scipy>=1.5.4",
   "tqdm>=4.0.0",


### PR DESCRIPTION
As some things of the polars api changed from 0.16 to 0.17 (`sep` was deprected in 0.16 and removed in 0.17 in favor of `separator`) we will have to update the minimal polars version.

I should have done this already in PR #315 
