### PR TITLE
refactor: Remove noqa:F401 and add imports via __all__

### DIFF
--- a/src/pymovements/__init__.py
+++ b/src/pymovements/__init__.py
@@ -17,17 +17,34 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""This module provides access to all submodules."""
-from pymovements import datasets  # noqa: F401
-from pymovements import events  # noqa: F401
-from pymovements import gaze  # noqa: F401
-from pymovements import plotting  # noqa: F401
-from pymovements import synthetic  # noqa: F401
-from pymovements import utils  # noqa: F401
-from pymovements.dataset import Dataset  # noqa: F401
-from pymovements.dataset import DatasetDefinition  # noqa: F401
-from pymovements.dataset import DatasetLibrary  # noqa: F401
-from pymovements.dataset import DatasetPaths  # noqa: F401
-from pymovements.dataset import register_dataset  # noqa: F401
-from pymovements.gaze.experiment import Experiment  # noqa: F401
-from pymovements.gaze.screen import Screen  # noqa: F401
+"""This module provides top-level access to all submodules."""
+from pymovements import datasets
+from pymovements import events
+from pymovements import gaze
+from pymovements import plotting
+from pymovements import synthetic
+from pymovements import utils
+from pymovements.dataset import Dataset
+from pymovements.dataset import DatasetDefinition
+from pymovements.dataset import DatasetLibrary
+from pymovements.dataset import DatasetPaths
+from pymovements.dataset import register_dataset
+from pymovements.gaze.experiment import Experiment
+from pymovements.gaze.screen import Screen
+
+
+__all__ = [
+    'Dataset',
+    'DatasetDefinition',
+    'DatasetLibrary',
+    'DatasetPaths',
+    'datasets',
+    'events',
+    'Experiment',
+    'gaze',
+    'plotting',
+    'register_dataset',
+    'Screen',
+    'synthetic',
+    'utils',
+]

--- a/src/pymovements/dataset/__init__.py
+++ b/src/pymovements/dataset/__init__.py
@@ -30,8 +30,17 @@
     pymovements.dataset.DatasetLibrary
     pymovements.dataset.DatasetPaths
 """
-from pymovements.dataset.dataset import Dataset  # noqa: F401
-from pymovements.dataset.dataset_definition import DatasetDefinition  # noqa: F401
-from pymovements.dataset.dataset_library import DatasetLibrary  # noqa: F401
-from pymovements.dataset.dataset_library import register_dataset  # noqa: F401
-from pymovements.dataset.dataset_paths import DatasetPaths  # noqa: F401
+from pymovements.dataset.dataset import Dataset
+from pymovements.dataset.dataset_definition import DatasetDefinition
+from pymovements.dataset.dataset_library import DatasetLibrary
+from pymovements.dataset.dataset_library import register_dataset
+from pymovements.dataset.dataset_paths import DatasetPaths
+
+
+__all__ = [
+    'Dataset',
+    'DatasetDefinition',
+    'DatasetLibrary',
+    'DatasetPaths',
+    'register_dataset',
+]

--- a/src/pymovements/datasets/__init__.py
+++ b/src/pymovements/datasets/__init__.py
@@ -29,6 +29,13 @@
     pymovements.datasets.GazeBase
     pymovements.datasets.JuDo1000
 """
-from pymovements.datasets.gazebase import GazeBase  # noqa: F401
-from pymovements.datasets.judo1000 import JuDo1000  # noqa: F401
-from pymovements.datasets.toy_dataset import ToyDataset  # noqa: F401
+from pymovements.datasets.gazebase import GazeBase
+from pymovements.datasets.judo1000 import JuDo1000
+from pymovements.datasets.toy_dataset import ToyDataset
+
+
+__all__ = [
+    'GazeBase',
+    'JuDo1000',
+    'ToyDataset',
+]

--- a/src/pymovements/events/__init__.py
+++ b/src/pymovements/events/__init__.py
@@ -60,10 +60,21 @@
     pymovements.events.event_properties.amplitude
     pymovements.events.event_properties.peak_velocity
 """
-from pymovements.events.detection.engbert import microsaccades  # noqa: F401
-from pymovements.events.detection.idt import idt  # noqa: F401
-from pymovements.events.detection.ivt import ivt  # noqa: F401
-from pymovements.events.event_processing import EventGazeProcessor  # noqa: F401
-from pymovements.events.event_processing import EventProcessor  # noqa: F401
-from pymovements.events.events import EventDataFrame  # noqa: F401
-from pymovements.events.events import EventDetectionCallable  # noqa: F401
+from pymovements.events.detection.engbert import microsaccades
+from pymovements.events.detection.idt import idt
+from pymovements.events.detection.ivt import ivt
+from pymovements.events.event_processing import EventGazeProcessor
+from pymovements.events.event_processing import EventProcessor
+from pymovements.events.events import EventDataFrame
+from pymovements.events.events import EventDetectionCallable
+
+
+__all__ = [
+    'microsaccades',
+    'idt',
+    'ivt',
+    'EventGazeProcessor',
+    'EventProcessor',
+    'EventDataFrame',
+    'EventDetectionCallable',
+]

--- a/src/pymovements/events/detection/__init__.py
+++ b/src/pymovements/events/detection/__init__.py
@@ -1,22 +1,3 @@
-# Copyright (c) 2023 The pymovements Project Authors
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 # Copyright (c) 2022-2023 The pymovements Project Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/pymovements/events/detection/__init__.py
+++ b/src/pymovements/events/detection/__init__.py
@@ -17,3 +17,45 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+# Copyright (c) 2022-2023 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""This module holds all event detection methods.
+
+.. rubric:: Detection Methods
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+    pymovements.events.detection.idt
+    pymovements.events.detection.ivt
+    pymovements.events.detection.microsaccades
+
+"""
+from pymovements.events.detection.engbert import microsaccades
+from pymovements.events.detection.idt import idt
+from pymovements.events.detection.ivt import ivt
+
+
+__all__ = [
+    'microsaccades',
+    'idt',
+    'ivt',
+]

--- a/src/pymovements/gaze/__init__.py
+++ b/src/pymovements/gaze/__init__.py
@@ -41,9 +41,9 @@
    pymovements.gaze.transforms.downsample
    pymovements.gaze.transforms.consecutive
 """
-from pymovements.gaze import transforms  # noqa: F401
+from pymovements.gaze import transforms
 from pymovements.gaze.experiment import Experiment
-from pymovements.gaze.gaze_dataframe import GazeDataFrame  # noqa: F401
+from pymovements.gaze.gaze_dataframe import GazeDataFrame
 from pymovements.gaze.screen import Screen
 
 

--- a/src/pymovements/plotting/__init__.py
+++ b/src/pymovements/plotting/__init__.py
@@ -30,14 +30,14 @@
     pymovements.plotting.traceplot
     pymovements.plotting.tsplot
 """
-from pymovements.plotting.heatmap import heatmap  # noqa: F401
-from pymovements.plotting.main_sequence_plot import main_sequence_plot  # noqa: F401
-from pymovements.plotting.traceplot import traceplot  # noqa: F401
-from pymovements.plotting.tsplot import tsplot  # noqa: F401
+from pymovements.plotting.heatmap import heatmap
+from pymovements.plotting.main_sequence_plot import main_sequence_plot
+from pymovements.plotting.traceplot import traceplot
+from pymovements.plotting.tsplot import tsplot
 
 __all__ = [
     'heatmap',
+    'main_sequence_plot',
     'traceplot',
     'tsplot',
-    'main_sequence_plot',
 ]

--- a/src/pymovements/synthetic/__init__.py
+++ b/src/pymovements/synthetic/__init__.py
@@ -27,4 +27,9 @@
     pymovements.synthetic.step_function
 
 """
-from pymovements.synthetic.step_function import step_function  # noqa: F401
+from pymovements.synthetic.step_function import step_function
+
+
+__all__ = [
+    'step_function',
+]

--- a/src/pymovements/utils/__init__.py
+++ b/src/pymovements/utils/__init__.py
@@ -33,9 +33,19 @@
     pymovements.utils.parsing
     pymovements.utils.paths
 """
-from pymovements.utils import archives  # noqa: F401
-from pymovements.utils import checks  # noqa: F401
-from pymovements.utils import decorators  # noqa: F401
-from pymovements.utils import downloads  # noqa: F401
-from pymovements.utils import parsing  # noqa: F401
-from pymovements.utils import paths  # noqa: F401
+from pymovements.utils import archives
+from pymovements.utils import checks
+from pymovements.utils import decorators
+from pymovements.utils import downloads
+from pymovements.utils import parsing
+from pymovements.utils import paths
+
+
+__all__ = [
+    'archives',
+    'checks',
+    'decorators',
+    'downloads',
+    'parsing',
+    'paths',
+]


### PR DESCRIPTION
## Description

This PR gets rid of all the `noqa: F401` statements for `flake8` by adding all the imports to the `__all__` variable.

## Implemented changes

- [x] added all imported modules to the `__all__` variable
- [x] removed all `noqa: F401` statements

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No additional tests are needed for this.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
