### PR TITLE
fix(ci): Add toml extra to coverage installation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 
 [testenv:coverage]
 deps =
-    coverage
+    coverage[toml]
 skip_install = True
 setenv =
     COVERAGE_FILE = .coverage


### PR DESCRIPTION
Some python versions complain about missing this extra when using a `pyproject.toml`