### PR TITLE
ci: Use conventional commits specification for autoupdate messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ci:
+    autoupdate_commit_msg: 'ci: pre-commit autoupdate'
     skip: [pylint]
 
 repos:


### PR DESCRIPTION
This PR changes the default pre-commit messages to the conventional commit specification.

For more details see: https://www.conventionalcommits.org/en/v1.0.0/

I will update the contributing guide soon with this spec too!