### PR TITLE
fix(plotting): Specify matplotlib backend explictly

### DIFF
--- a/src/pymovements/plotting/traceplot.py
+++ b/src/pymovements/plotting/traceplot.py
@@ -31,6 +31,8 @@ from matplotlib.collections import LineCollection
 from pymovements.gaze.gaze_dataframe import GazeDataFrame
 
 
+matplotlib.use('Agg')
+
 DEFAULT_SEGMENTDATA = {
     'red': [
         [0.0, 0.0, 0.0],


### PR DESCRIPTION
okay, next try...

It's seems to me that it's always the `traceplot()` function that fails.
So now let's try to specify this in the module like it was done in https://github.com/microsoft/azure-pipelines-tasks/issues/16426

If that won't work I will have to review the plot function a bit more.

hopefully fixes #324 