### PR TITLE
feat(events): Add support for custom event names

### DIFF
--- a/src/pymovements/events/__init__.py
+++ b/src/pymovements/events/__init__.py
@@ -27,7 +27,6 @@
    :template: class.rst
 
     pymovements.events.EventDataFrame
-    pymovements.events.EventDetectionCallable
 
 .. rubric:: Processing
 

--- a/src/pymovements/events/__init__.py
+++ b/src/pymovements/events/__init__.py
@@ -27,7 +27,6 @@
    :template: class.rst
 
     pymovements.events.EventDataFrame
-    pymovements.events.EventDetectionCallable
 
 .. rubric:: Processing
 
@@ -66,7 +65,6 @@ from pymovements.events.detection.microsaccades import microsaccades
 from pymovements.events.event_processing import EventGazeProcessor
 from pymovements.events.event_processing import EventProcessor
 from pymovements.events.events import EventDataFrame
-from pymovements.events.events import EventDetectionCallable
 
 
 __all__ = [
@@ -76,5 +74,4 @@ __all__ = [
     'EventGazeProcessor',
     'EventProcessor',
     'EventDataFrame',
-    'EventDetectionCallable',
 ]

--- a/src/pymovements/events/detection/idt.py
+++ b/src/pymovements/events/detection/idt.py
@@ -57,6 +57,7 @@ def idt(
         minimum_duration: int = 100,
         dispersion_threshold: float = 1.0,
         include_nan: bool = False,
+        name: str = 'fixation',
 ) -> EventDataFrame:
     """
     Fixation identification based on dispersion threshold.
@@ -86,6 +87,8 @@ def idt(
         Threshold for dispersion for a group of consecutive samples to be identified as fixation
     include_nan: bool
         Indicator, whether we want to split events on missing/corrupt value (np.nan)
+    name:
+        Name for detected events in EventDataFrame.
 
     Returns
     -------
@@ -208,5 +211,5 @@ def idt(
     onsets_arr = np.array(onsets).flatten()
     offsets_arr = np.array(offsets).flatten()
 
-    event_df = EventDataFrame(name='fixation', onsets=onsets_arr, offsets=offsets_arr)
+    event_df = EventDataFrame(name=name, onsets=onsets_arr, offsets=offsets_arr)
     return event_df

--- a/src/pymovements/events/detection/ivt.py
+++ b/src/pymovements/events/detection/ivt.py
@@ -38,6 +38,7 @@ def ivt(
         minimum_duration: int = 100,
         velocity_threshold: float = 20.0,
         include_nan: bool = False,
+        name: str = 'fixation',
 ) -> EventDataFrame:
     """
     Identification of fixations based on velocity-threshold
@@ -66,6 +67,8 @@ def ivt(
         velocity is below the threshold, the point is classified as a fixation.
     include_nan: bool
         Indicator, whether we want to split events on missing/corrupt value (np.nan)
+    name:
+        Name for detected events in EventDataFrame.
 
     Returns
     -------
@@ -125,5 +128,5 @@ def ivt(
     offsets = timesteps[[candidate_indices[-1] for candidate_indices in candidates]].flatten()
 
     # Create event dataframe from onsets and offsets.
-    event_df = EventDataFrame(name='fixation', onsets=onsets, offsets=offsets)
+    event_df = EventDataFrame(name=name, onsets=onsets, offsets=offsets)
     return event_df

--- a/src/pymovements/events/detection/microsaccades.py
+++ b/src/pymovements/events/detection/microsaccades.py
@@ -41,6 +41,7 @@ def microsaccades(
         threshold_factor: float = 6,
         minimum_threshold: float = 1e-10,
         include_nan: bool = False,
+        name: str = 'saccade',
 ) -> EventDataFrame:
     """Detect micro-saccades from velocity gaze sequence.
 
@@ -74,6 +75,8 @@ def microsaccades(
         Default: 1e-10
     include_nan: bool
         Indicator, whether we want to split events on missing/corrupt value (np.nan)
+    name:
+        Name for detected events in EventDataFrame.
 
     Returns
     -------
@@ -142,7 +145,7 @@ def microsaccades(
     offsets = timesteps[[candidate_indices[-1] for candidate_indices in candidates]].flatten()
 
     # Create event dataframe from onsets and offsets.
-    event_df = EventDataFrame(name='saccade', onsets=onsets, offsets=offsets)
+    event_df = EventDataFrame(name=name, onsets=onsets, offsets=offsets)
     return event_df
 
 

--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -172,38 +172,3 @@ class EventDataFrame:
             ] + [pl.all()],
         )
         return df
-
-
-class EventDetectionCallable(Protocol):
-    """Minimal interface to be implemented by all event detection methods."""
-
-    def __call__(
-            self,
-            positions: list[list[float]] | list[tuple[float, float]] | np.ndarray,
-            velocities: list[list[float]] | list[tuple[float, float]] | np.ndarray,
-            timesteps: list[int] | np.ndarray | None = None,
-            minimum_duration: int = 0,
-            **kwargs: int | str | float,
-    ) -> EventDataFrame:
-        """Minimal interface to be implemented by all event detection methods.
-
-        Parameters
-        ----------
-        positions: array-like, shape (N, 2)
-            Continuous 2D position time series
-        velocities: array-like, shape (N, 2)
-            Corresponding continuous 2D velocity time series.
-        timesteps: array-like, shape (N, )
-            Corresponding continuous 1D timestep time series. If None, sample based timesteps are
-            assumed.
-        minimum_duration: int
-            Minimum event duration. The duration is specified in the units used in ``timesteps``.
-            If ``timesteps`` is None, then ``minimum_duration`` is specified in numbers of samples.
-        **kwargs:
-            Additional keyword arguments for the specific event detection method.
-
-        Returns
-        -------
-        EventDataFrame
-            A dataframe with detected events as rows.
-        """

--- a/tests/events/detection/idt_test.py
+++ b/tests/events/detection/idt_test.py
@@ -153,6 +153,20 @@ def test_idt_raises_error(kwargs, expected_error):
         ),
         pytest.param(
             {
+                'positions': pm.synthetic.step_function(length=100, steps=[0], values=[(0, 0)]),
+                'dispersion_threshold': 1,
+                'minimum_duration': 2,
+                'name': 'custom_fixation',
+            },
+            pm.events.EventDataFrame(
+                name='custom_fixation',
+                onsets=[0],
+                offsets=[99],
+            ),
+            id='constant_position_single_fixation_custom_name',
+        ),
+        pytest.param(
+            {
                 'positions': pm.synthetic.step_function(
                     length=100,
                     steps=[49, 50],

--- a/tests/events/detection/ivt_test.py
+++ b/tests/events/detection/ivt_test.py
@@ -188,6 +188,20 @@ def test_ivt_raise_error(kwargs, expected_error):
         ),
         pytest.param(
             {
+                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
+                'velocity_threshold': 1,
+                'minimum_duration': 1,
+                'name': 'custom_fixation',
+            },
+            EventDataFrame(
+                name='custom_fixation',
+                onsets=[0],
+                offsets=[99],
+            ),
+            id='constant_position_single_fixation_custom_name',
+        ),
+        pytest.param(
+            {
                 'positions': step_function(
                     length=100,
                     steps=[49, 50],

--- a/tests/events/detection/microsaccades_test.py
+++ b/tests/events/detection/microsaccades_test.py
@@ -105,6 +105,25 @@ def test_microsaccades_raises_error(kwargs, expected):
                 'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
                 'velocities': step_function(
                     length=100,
+                    steps=[40, 50],
+                    values=[(9, 9), (0, 0)],
+                    start_value=(0, 0),
+                ),
+                'threshold': 1e-5,
+                'name': 'custom_saccade',
+            },
+            EventDataFrame(
+                name='custom_saccade',
+                onsets=[40],
+                offsets=[49],
+            ),
+            id='two_steps_one_saccade_custom_name',
+        ),
+        pytest.param(
+            {
+                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
+                'velocities': step_function(
+                    length=100,
                     steps=[20, 30, 70, 80],
                     values=[(9, 9), (0, 0), (9, 9), (0, 0)],
                     start_value=(0, 0),


### PR DESCRIPTION
## Description

This makes it possible to specify custom event names for your detected events like this:

```python
dataset.detect_events('idt', name='fixation.idt')
dataset.detect_events('ivt', name='fixation.ivt')
```

fixes #321

## Implemented changes

- [x] Added `name` parameter to event detection functions
- [x] Updated event detection tutorial to show this feature

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change is or requires a documentation update

## How Has This Been Tested?

- [x] Added test cases to each event detection function

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
