### PR TITLE
feat(dataset): Allow range-objects for subset argument

### DIFF
--- a/docs/source/tutorials/pymovements-in-10-minutes.ipynb
+++ b/docs/source/tutorials/pymovements-in-10-minutes.ipynb
@@ -203,7 +203,9 @@
     "The last two columns refer to the pixel coordinates at the timestep specified by `time`.\n",
     "\n",
     "\n",
-    "We are also able to just take a subset of the data by specifying values of the fileinfo columns:\n"
+    "We are also able to just take a subset of the data by specifying values of the fileinfo columns.\n",
+    "The key refers to the column in the `fileinfo` dataframe.\n",
+    "The values in the dictionary can be of type `bool`, `int`,  `float` or `str`, but also lists and ranges \n"
    ]
   },
   {
@@ -214,8 +216,8 @@
    "outputs": [],
    "source": [
     "subset = {\n",
-    "    'text_id': [0],\n",
-    "    'page_id': [0, 1, 2],\n",
+    "    'text_id': 0,\n",
+    "    'page_id': range(3),\n",
     "}\n",
     "dataset.load(subset=subset)\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "matplotlib>=3.0.0",
   "numpy>=1.10.0",
   "pandas>1.0.0",
-  "polars>=0.17.2",
+  "polars>=0.17.2,<0.18",
   "pyarrow>=4.0.0",
   "scipy>=1.5.4",
   "tqdm>=4.0.0",

--- a/src/pymovements/dataset/dataset_files.py
+++ b/src/pymovements/dataset/dataset_files.py
@@ -496,12 +496,12 @@ def take_subset(
 
         if isinstance(subset_value, (bool, float, int, str)):
             column_values = [subset_value]
-        elif isinstance(subset_value, (list, tuple)):
+        elif isinstance(subset_value, (list, tuple, range)):
             column_values = subset_value
         else:
             raise TypeError(
-                f'subset value must be of type bool, float, int, str or a list of these but'
-                f' key-value pair {subset_key}: {subset_value} is of type {type(subset_value)}',
+                f'subset values must be of type bool, float, int, str, range, or list, '
+                f'but value of pair {subset_key}: {subset_value} is of type {type(subset_value)}',
             )
 
         fileinfo = fileinfo.filter(pl.col(subset_key).is_in(column_values))

--- a/tests/dataset/dataset_test.py
+++ b/tests/dataset/dataset_test.py
@@ -316,12 +316,17 @@ def test_load_correct_event_dfs(dataset_configuration):
         pytest.param(
             {'subject_id': 1},
             [0],
-            id='subset_key_not_in_fileinfo',
+            id='subset_int',
         ),
         pytest.param(
             {'subject_id': [1, 11, 12]},
             [0, 2, 3],
-            id='subset_key_not_in_fileinfo',
+            id='subset_list',
+        ),
+        pytest.param(
+            {'subject_id': range(3)},
+            [0, 11],
+            id='subset_range',
         ),
     ],
 )


### PR DESCRIPTION
## Description

This allows range objects to be passed in the `subset` argument in `dataset.load()` 

## Implemented changes

The polars function `is_in()` works perfectly well with range objects, so I just needed to add this as a valid value type.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change is or requires a documentation update

## How Has This Been Tested?

- [x] I added a single test case which passes a range object as a value

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
