### PR TITLE
fix: Keep polars version below v0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "matplotlib>=3.0.0",
   "numpy>=1.10.0",
   "pandas>1.0.0",
-  "polars>=0.17.2",
+  "polars>=0.17.2,<0.18",
   "pyarrow>=4.0.0",
   "scipy>=1.5.4",
   "tqdm>=4.0.0",


### PR DESCRIPTION
there are still some small details to work out to migrate to polars v0.18

in the meantime we will stay safely below