### PR TITLE
feat: Add styling arguments to main sequence plot

### DIFF
--- a/docs/source/tutorials/plot-main-sequence.ipynb
+++ b/docs/source/tutorials/plot-main-sequence.ipynb
@@ -197,7 +197,7 @@
     "        alpha=0.3,\n",
     "        color='green',\n",
     "        marker='x',\n",
-    "        maker_size=30,\n",
+    "        marker_size=30,\n",
     "    )"
    ]
   },

--- a/docs/source/tutorials/plot-main-sequence.ipynb
+++ b/docs/source/tutorials/plot-main-sequence.ipynb
@@ -16,7 +16,7 @@
     "## What you will learn in this tutorial:\n",
     "\n",
     "* how to prepare your data to plot the saccadic main sequence\n",
-    "* how to create a main sequence plot of your saccade events"
+    "* how to create a main sequence plot of your saccade events and style it to your liking"
    ]
   },
   {
@@ -186,12 +186,19 @@
    "outputs": [],
    "source": [
     "# only showing the first three event dataframes here.\n",
+    "# note that you can adjust the styling of the plot, e.g. setting a low\n",
+    "# alpha value allows you to see overlapping data points\n",
     "for event_df in dataset.events[:3]:\n",
-    "    print(\n",
-    "        f'Showing main sequence plot for '\n",
+    "    pm.plotting.main_sequence_plot(\n",
+    "        event_df,\n",
+    "        title='Main sequence plot for '\n",
     "        f'text {event_df[0, \"text_id\"]}, '\n",
-    "        f'page {event_df[0, \"page_id\"]}:')\n",
-    "    pm.plotting.main_sequence_plot(event_df)"
+    "        f'page {event_df[0, \"page_id\"]}',\n",
+    "        alpha=0.3,\n",
+    "        color='green',\n",
+    "        marker='x',\n",
+    "        maker_size=30,\n",
+    "    )"
    ]
   },
   {

--- a/src/pymovements/plotting/main_sequence_plot.py
+++ b/src/pymovements/plotting/main_sequence_plot.py
@@ -31,18 +31,31 @@ from pymovements.events import EventDataFrame
 
 def main_sequence_plot(
         event_df: EventDataFrame,
+        marker_size: float = 25,
+        color: str = 'purple',
+        alpha: float = 0.5,
+        marker: str = 'o',
         figsize: tuple[int, int] = (15, 5),
         title: str | None = None,
         savepath: str | None = None,
         show: bool = True,
+        **kwargs,
 ) -> None:
     """
     Plots the saccade main sequence.
 
     Parameters
     ----------
-    event_df:
-        Event dataframe. It must contain columns "peak_velocity" and "amplitude".
+    event_df: Event dataframe
+        It must contain columns "peak_velocity" and "amplitude".
+    marker_size: float
+        Size of the marker symbol.
+    color: str
+        Color of the marker symbol.
+    alpha: float
+        Alpha value (=transparency) of the marker symbol. Between 0 and 1.
+    marker: str
+        Marker symbol. Possible values defined by matplotlib.markers.
     figsize: tuple
         Figure size.
     title: str, optional
@@ -51,6 +64,8 @@ def main_sequence_plot(
         If given, figure will be saved to this path.
     show: bool
         If True, figure will be shown.
+    **kwargs:
+        Additional keyword arguments passed to matplotlib.pyplot.scatter.
 
     Raises
     ------
@@ -90,7 +105,15 @@ def main_sequence_plot(
 
     fig = plt.figure(figsize=figsize)
 
-    plt.scatter(amplitudes, peak_velocities, color='purple', alpha=0.5)
+    plt.scatter(
+        amplitudes,
+        peak_velocities,
+        color=color,
+        alpha=alpha,
+        s=marker_size,
+        marker=marker,
+        **kwargs,
+    )
 
     plt.title(title)
     plt.xlabel('Amplitude [dva]')

--- a/src/pymovements/plotting/main_sequence_plot.py
+++ b/src/pymovements/plotting/main_sequence_plot.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import matplotlib.pyplot as plt
 import polars as pl
+from matplotlib.collections import Collection
 from polars import ColumnNotFoundError
 
 from pymovements.events import EventDataFrame
@@ -39,7 +40,7 @@ def main_sequence_plot(
         title: str | None = None,
         savepath: str | None = None,
         show: bool = True,
-        **kwargs,
+        **kwargs: Collection,
 ) -> None:
     """
     Plots the saccade main sequence.

--- a/tests/plotting/main_sequence_plot_test.py
+++ b/tests/plotting/main_sequence_plot_test.py
@@ -30,7 +30,7 @@ from pymovements.plotting.main_sequence_plot import main_sequence_plot
 
 
 @pytest.mark.parametrize(
-    ('input_df', 'show'),
+    ('input_df', 'show', 'color', 'marker', 'alpha', 'size'),
     [
         pytest.param(
             EventDataFrame(
@@ -44,25 +44,38 @@ from pymovements.plotting.main_sequence_plot import main_sequence_plot
                 ),
             ),
             True,
+            'blue',
+            'x',
+            0.6,
+            30,
             id='show_plot',
         ),
     ],
 )
-def test_main_sequence_plot_show_plot(input_df, show, monkeypatch):
+def test_main_sequence_plot_show_plot(input_df, show, monkeypatch, color, marker, alpha, size):
     mock_show = Mock()
     mock_scatter = Mock()
 
     monkeypatch.setattr(plt, 'show', mock_show)
     monkeypatch.setattr(plt, 'scatter', mock_scatter)
 
-    main_sequence_plot(input_df, show=show)
+    main_sequence_plot(
+        input_df,
+        show=show,
+        color=color,
+        marker=marker,
+        alpha=alpha,
+        marker_size=size,
+    )
     plt.close()
 
     mock_scatter.assert_called_with(
         [1.0, 1.0, 2.0, 2.0, 3.0, 4.0],
         [10.0, 11.0, 12.0, 11.0, 13.0, 13.0],
-        color='purple',
-        alpha=0.5,
+        color='blue',
+        alpha=0.6,
+        s=30,
+        marker='x',
     )
 
     mock_show.assert_called_once()
@@ -99,6 +112,8 @@ def test_main_sequence_plot_filter_out_fixations(input_df, monkeypatch):
         [10.0, 11.0, 12.0, 11.0, 13.0],
         color='purple',
         alpha=0.5,
+        s=25,
+        marker='o',
     )
 
 


### PR DESCRIPTION
## Description

Fixes issue #449 

## Implemented changes

- [x] Added styling args to main sequence plot: color, marker_size, ...
- [x] possible to add further kwargs for plot.scatter

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
