### PR TITLE
Update GazeDataFrame Docstring to Include Missing trial_columns Argument

### DIFF
--- a/src/pymovements/gaze/gaze_dataframe.py
+++ b/src/pymovements/gaze/gaze_dataframe.py
@@ -95,6 +95,11 @@ class GazeDataFrame:
             A dataframe to be transformed to a polars dataframe.
         experiment : Experiment
             The experiment definition.
+        trial_columns:
+            The name of the trial columns in the input data frame. If the list is empty or None,
+            the input data frame is assumed to contain only one trial. If the list is not empty,
+            the input data frame is assumed to contain multiple trials and the transformation
+            methods will be applied to each trial separately.
         time_column:
             The name if the timestamp column in the input data frame.
         pixel_columns:


### PR DESCRIPTION
 I noticed the `trial_columns` argument was missing from the docstring of `GazeDataFrame`'s constructor. Added it to clarify the usage and effect of this argument.

## Changes

- Updated the `GazeDataFrame` constructor docstring to include a explanation for the `trial_columns` parameter.

## Type of Change

- [x] Docs update