### PR TITLE
feat: Add time_column argument to gaze.integration functions

### DIFF
--- a/src/pymovements/gaze/gaze_dataframe.py
+++ b/src/pymovements/gaze/gaze_dataframe.py
@@ -101,7 +101,7 @@ class GazeDataFrame:
             the input data frame is assumed to contain multiple trials and the transformation
             methods will be applied to each trial separately.
         time_column:
-            The name if the timestamp column in the input data frame.
+            The name of the timestamp column in the input data frame.
         pixel_columns:
             The name of the pixel position columns in the input data frame. These columns will be
             nested into the column ``pixel``. If the list is empty or None, the nested ``pixel``

--- a/src/pymovements/gaze/integration.py
+++ b/src/pymovements/gaze/integration.py
@@ -35,6 +35,7 @@ def from_numpy(
         schema: list[str],
         experiment: Experiment | None = None,
         orient: Literal['col', 'row'] = 'col',
+        time_column: str | None = None,
         pixel_columns: list[str] | None = None,
         position_columns: list[str] | None = None,
         velocity_columns: list[str] | None = None,
@@ -53,6 +54,9 @@ def from_numpy(
         Whether to interpret the two-dimensional data as columns or as rows.
     experiment : Experiment
         The experiment definition.
+            time_column: str | None = None,
+    time_column:
+        The name of the timestamp column in the input data frame.
     pixel_columns:
         The name of the pixel position columns in the input data frame.
     position_columns:
@@ -70,6 +74,7 @@ def from_numpy(
     return GazeDataFrame(
         data=df,
         experiment=experiment,
+        time_column=time_column,
         pixel_columns=pixel_columns,
         position_columns=position_columns,
         velocity_columns=velocity_columns,
@@ -80,6 +85,7 @@ def from_numpy(
 def from_pandas(
         data: pd.DataFrame,
         experiment: Experiment | None = None,
+        time_column: str | None = None,
         pixel_columns: list[str] | None = None,
         position_columns: list[str] | None = None,
         velocity_columns: list[str] | None = None,
@@ -94,6 +100,8 @@ def from_pandas(
         Data represented as a pandas DataFrame.
     experiment : Experiment
         The experiment definition.
+    time_column:
+        The name of the timestamp column in the input data frame.
     pixel_columns:
         The name of the pixel position columns in the input data frame.
     position_columns:
@@ -111,6 +119,7 @@ def from_pandas(
     return GazeDataFrame(
         data=df,
         experiment=experiment,
+        time_column=time_column,
         pixel_columns=pixel_columns,
         position_columns=position_columns,
         velocity_columns=velocity_columns,


### PR DESCRIPTION
The `time_column` argument was missing from both `gaze.integration.from_numpy()` and `gaze.integration.from_pandas()`