### PR TITLE
chore: Integrate dependabot to check for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build: "
+      include: "scope"


### PR DESCRIPTION
With this PR dependabot should create weekly PRs for updated packages.

See https://docs.github.com/en/code-security/dependabot for reference.

Let's see if that works.