### PR TITLE
build: don't include scope in dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,3 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build: "
-      include: "scope"


### PR DESCRIPTION
## Description

I made an error when writing the config, the scope should not be included in the commit messages