### PR TITLE
feat: Add EventDataFrame.clone()

### DIFF
--- a/src/pymovements/events/frame.py
+++ b/src/pymovements/events/frame.py
@@ -164,6 +164,16 @@ class EventDataFrame:
         event_property_columns -= set(self._additional_columns)
         return list(event_property_columns)
 
+    def copy(self) -> EventDataFrame:
+        """Return a copy of the EventDataFrame.
+
+        Returns
+        -------
+        EventDataFrame
+            A copy of the EventDataFrame.
+        """
+        return EventDataFrame(data=self.frame.clone())
+
     def _add_minimal_schema_columns(self, df: pl.DataFrame) -> pl.DataFrame:
         """Add minimal schema columns to :py:class:`polars.DataFrame` if they are missing."""
         if len(df) == 0:

--- a/tests/events/frame_test.py
+++ b/tests/events/frame_test.py
@@ -186,3 +186,13 @@ def test_event_dataframe_columns_same_as_frame():
     event_df = pm.EventDataFrame(**init_kwargs)
 
     assert event_df.columns == event_df.frame.columns
+
+
+def test_event_dataframe_copy():
+    events = pm.EventDataFrame(name='saccade', onsets=[0], offsets=[123])
+    events_copy = events.copy()
+
+    # We want to have separate dataframes but with the exact same data.
+    assert events is not events_copy
+    assert events.frame is not events_copy.frame
+    assert_frame_equal(events.frame, events_copy.frame)


### PR DESCRIPTION
## Description

Adds simple clone method to EventDataFrame class. Needed in #553

## Implemented changes

- [x] EventDataFrame.clone()

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested that copied dataframe has same values
- [x] Tested that dataframes point to different instances

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
