### PR TITLE
ci: Remove mypy and flake8 from tox and github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,25 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  pylint:
+    name: pylint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install base python for tox
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Setup test environment
+        run: tox -vv --notest -e pylint
+      - name: Run test
+        run: tox --skip-pkg-install -e pylint
+
+
   docs:
     name: docs (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,33 +53,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  check:
-    name: check ${{ matrix.tox_env }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        tox_env:
-          - flake8
-          - pylint
-          - mypy
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install base python for tox
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - name: Install tox
-        run: python -m pip install tox
-      - name: Setup test environment
-        run: tox -vv --notest -e ${{ matrix.tox_env }}
-      - name: Run test
-        run: tox --skip-pkg-install -e ${{ matrix.tox_env }}
-
   docs:
     name: docs (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,8 @@ ci:
     autoupdate_commit_msg: 'ci: pre-commit autoupdate'
     skip: [pylint]
 
+default_stages: [push]
+
 repos:
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v3.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,13 +127,24 @@ We use [`flake8`](https://pypi.org/project/flake8/) for quick style checks and
 [`pylint`](https://pypi.org/project/pylint/) for thorough style checks and [`mypy`](
 https://pypi.org/project/mypy/) for checking type annotations.
 
-You can check your code style by using [pre-commit](https://www.pre-commit.com). You can install `pre-commit` via pip:
+You can check your code style by using [pre-commit](https://www.pre-commit.com).
+You can install `pre-commit` via pip:
 
 ```bash
 pip install pre-commit
 pip install pylint
-pre-commit install
 ```
+
+To run all our style for your pushed files simply use
+```bash
+pre-commit install --hook-type pre-push
+```
+
+If you want to run pre-commit for all your staged files use
+```bash
+pre-commit run --all-files
+```
+
 
 ### Testing
 
@@ -145,7 +156,7 @@ If you have not yet installed `tox` you can do so via
 pip install tox
 ```
 
-A full style check and all tests can be run by simply calling `tox` in the repository root.
+You can run all tests on all supported python versions run by simply calling `tox` in the repository root.
 ```bash
 tox
 ```
@@ -176,7 +187,9 @@ You can build the documentation locally using the respective tox environment:
 tox -e docs
 ```
 It will appear in the `build/docs` directory.
-Please note that in order to reproduce the documentation locally, you may need to install `pandoc`. If necessary, please refer to the [installation guide](https://pandoc.org/installing.html) for detailed instructions.
+Please note that in order to reproduce the documentation locally, you may need to install `pandoc`.
+If necessary, please refer to the [installation guide](https://pandoc.org/installing.html) for
+detailed instructions.
 
 To rebuild the full documentation use
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,14 +135,36 @@ pip install pre-commit
 pip install pylint
 ```
 
-To run all our style for your pushed files simply use
+To always run style checks when pushing commits upstream you can register a pre-push hook by
 ```bash
 pre-commit install --hook-type pre-push
 ```
 
-If you want to run pre-commit for all your staged files use
+If you want to run pre-commit for all your currently staged files simply use
+```bash
+pre-commit
+```
+You can find the names of all defined hooks in the file `.pre-commit-config.yaml`.
+
+If you want to run a specific hook you can use
+```bash
+pre-commit run mypy
+pre-commit run pydocstyle
+```
+
+If you want to run a specific hook on a single file you can use
+```bash
+pre-commit run mypy --files src/pymovements/gaze/transforms.py
+```
+
+If you want to run all hooks on all git repository files use
 ```bash
 pre-commit run -a
+```
+
+For running a specific hook on all git repository files use
+```bash
+pre-commit run mypy -a
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ pre-commit install --hook-type pre-push
 
 If you want to run pre-commit for all your staged files use
 ```bash
-pre-commit run --all-files
+pre-commit run -a
 ```
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,19 @@ commands =
         "{toxinidir}/docs/build" \
         {posargs}
 
+
+[testenv:pylint]
+deps =
+    pylint
+    pytest
+changedir = {toxinidir}
+commands =
+    pylint --rcfile=pylintrc --output-format=parseable --ignore-paths={toxinidir}/src/pymovements/_version.py \
+    {toxinidir}/src/pymovements
+    pylint --rcfile=pylintrc --output-format=parseable \
+    --disable=missing-class-docstring,missing-function-docstring,protected-access {toxinidir}/tests
+
+
 [flake8]
 exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
 max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,7 @@ envlist =
     py39
     py310
     py311
-    pylint
-    flake8
     docs
-    mypy
     coverage
 
 
@@ -53,39 +50,3 @@ commands =
         "{toxinidir}/docs/source" \
         "{toxinidir}/docs/build" \
         {posargs}
-
-
-[testenv:flake8]
-deps =
-    flake8
-changedir = {toxinidir}
-commands =
-    flake8 "{toxinidir}/src/pymovements" "{toxinidir}/tests" {posargs}
-
-
-[testenv:pylint]
-deps =
-    pylint
-    pytest
-changedir = {toxinidir}
-commands =
-    pylint --rcfile=pylintrc --output-format=parseable --ignore-paths={toxinidir}/src/pymovements/_version.py \
-    {toxinidir}/src/pymovements
-    pylint --rcfile=pylintrc --output-format=parseable \
-    --disable=missing-class-docstring,missing-function-docstring,protected-access {toxinidir}/tests
-
-
-[testenv:mypy]
-changedir = {toxinidir}
-deps =
-    mypy
-    pandas-stubs
-    types-all
-    types-tqdm
-commands =
-    mypy {toxinidir}/src
-
-
-[flake8]
-exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
-max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -50,3 +50,7 @@ commands =
         "{toxinidir}/docs/source" \
         "{toxinidir}/docs/build" \
         {posargs}
+
+[flake8]
+exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
+max-line-length = 100


### PR DESCRIPTION
## Description

As proposed in #573 linting is now completely run by using pre-commit

Fixes issue #573
