### PR TITLE
ci: test for minimum version of dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,36 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  minimum-requirements:
+    name: check minimum requirements (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    env:
+      MPLBACKEND: Agg
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        tox_env:
+          - py39
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install base python for tox
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Install python for test
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Setup test environment
+        run: MIN_REQ=1 tox -vv --notest -e py39
+      - name: Run test
+        run: MIN_REQ=1 tox --skip-pkg-install -e py39


### PR DESCRIPTION
currently we do not test our minimum versions of dependencies. this lead to errors in the past, where users had old openssl packages installed.

this pr adds a test for our minimum supported versions.