### PR TITLE
fix: specify schema for ToyDatasetEyeLink

### DIFF
--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -175,6 +175,11 @@ class ToyDatasetEyeLink(DatasetDefinition):
                     'value': None,
                 },
             ],
-            'schema': {'trial_id': pl.Int64},
+            'schema': {
+                'trial_id': pl.Int64,
+                'screen_id': pl.Int64,
+                'point_id': pl.Int64,
+                'task': pl.Utf8,
+            },
         },
     )


### PR DESCRIPTION
the schema for the ToyDatasetEyeLink was not specified correctly.

Needed to be merged for #590 to work properly