### PR TITLE
ci: treat warnings as errors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ import importlib.metadata
 import inspect
 import os
 import sys
+from pathlib import Path
 from subprocess import CalledProcessError
 from subprocess import run
 
@@ -216,7 +217,7 @@ def linkcode_resolve(domain, info):
             return None
 
     try:
-        modpath = importlib.metadata.requires(topmodulename)[0].location
+        modpath = Path(importlib.metadata.requires(topmodulename)[0]).location
         filepath = os.path.relpath(inspect.getsourcefile(obj), modpath)
         if filepath is None:
             return

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import importlib.metadata
 import inspect
 import os
 import sys
@@ -35,6 +34,7 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from subprocess import run
 
+import pkg_resources
 from pybtex.plugin import register_plugin
 from pybtex.style.formatting.plain import Style as PlainStyle
 from pybtex.style.labels import BaseLabelStyle
@@ -217,7 +217,7 @@ def linkcode_resolve(domain, info):
             return None
 
     try:
-        modpath = Path(importlib.metadata.requires(topmodulename)[0]).location
+        modpath = pkg_resources.require(topmodulename)[0].location
         filepath = os.path.relpath(inspect.getsourcefile(obj), modpath)
         if filepath is None:
             return

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,13 +27,13 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import importlib.metadata
 import inspect
 import os
 import sys
 from subprocess import CalledProcessError
 from subprocess import run
 
-import pkg_resources
 from pybtex.plugin import register_plugin
 from pybtex.style.formatting.plain import Style as PlainStyle
 from pybtex.style.labels import BaseLabelStyle
@@ -216,7 +216,7 @@ def linkcode_resolve(domain, info):
             return None
 
     try:
-        modpath = pkg_resources.require(topmodulename)[0].location
+        modpath = importlib.metadata.requires(topmodulename)[0].location
         filepath = os.path.relpath(inspect.getsourcefile(obj), modpath)
         if filepath is None:
             return

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,6 @@
 import inspect
 import os
 import sys
-from pathlib import Path
 from subprocess import CalledProcessError
 from subprocess import run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ filterwarnings = [
   "ignore:pkg_resources is deprecated.*:DeprecationWarning",
   "ignore:`groupby` is deprecated. It has been renamed to `group_by`.:DeprecationWarning",
   "ignore:`map` is deprecated. It has been renamed to `map_batches`.:DeprecationWarning",
+  "ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning",
 ]
 testpaths = ['tests', 'src']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
+  "ignore::DeprecationWarning",
   "ignore::DeprecationWarning:pkg_resources",
   "ignore::DeprecationWarning:pkg_resources.*:",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ filterwarnings = [
   "error",
   "ignore:Both a distance column and experiment.*:UserWarning",
   "ignore:pkg_resources is deprecated.*:DeprecationWarning",
+  "ignore:Deprecated call to `pkg_resources.declare_namespace.*:DeprecationWarning",
   "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
   "ignore:`groupby` is deprecated. It has been renamed to `group_by`.:DeprecationWarning",
   "ignore:`lengths` is deprecated. It has been renamed to `len`.:DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,8 +132,6 @@ filterwarnings = [
   "error",
   "ignore:Both a distance column and experiment.*:UserWarning",
   "ignore::DeprecationWarning",
-  "ignore::DeprecationWarning:pkg_resources",
-  "ignore::DeprecationWarning:pkg_resources.*:",
 ]
 testpaths = ['tests', 'src']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ filterwarnings = [
   "error",
   "ignore:Both a distance column and experiment.*:UserWarning",
   "ignore:pkg_resources is deprecated.*:DeprecationWarning",
+  "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
   "ignore:`groupby` is deprecated. It has been renamed to `group_by`.:DeprecationWarning",
   "ignore:`lengths` is deprecated. It has been renamed to `len`.:DeprecationWarning",
   "ignore:`map` is deprecated. It has been renamed to `map_batches`.:DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
-  "ignore::UserWarning",
+  "ignore:Both a distance column and experiment.*:UserWarning",
   "ignore::DeprecationWarning",
   "ignore::DeprecationWarning:pkg_resources",
   "ignore::DeprecationWarning:pkg_resources.*:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ filterwarnings = [
   "ignore:Both a distance column and experiment.*:UserWarning",
   "ignore:pkg_resources is deprecated.*:DeprecationWarning",
   "ignore:`groupby` is deprecated. It has been renamed to `group_by`.:DeprecationWarning",
+  "ignore:`lengths` is deprecated. It has been renamed to `len`.:DeprecationWarning",
   "ignore:`map` is deprecated. It has been renamed to `map_batches`.:DeprecationWarning",
   "ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
+  "ignore::DeprecationWarning:pkg_resources",
   "ignore::DeprecationWarning:pkg_resources.*:",
 ]
 testpaths = ['tests', 'src']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
   "ignore:Both a distance column and experiment.*:UserWarning",
-]
+  "ignore:pkg_resources is deprecated.*:DeprecationWarning"]
 testpaths = ['tests', 'src']
 
 [tool.setuptools-git-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,10 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
-filterwarnings = "error"
+filterwarnings = [
+  "error",
+  "ignore::DeprecationWarning:pkg_resources.*:",
+]
 testpaths = ['tests', 'src']
 
 [tool.setuptools-git-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ filterwarnings = [
   "error",
   "ignore:Both a distance column and experiment.*:UserWarning",
   "ignore:pkg_resources is deprecated.*:DeprecationWarning",
+  "ignore:`groupby` is deprecated. It has been renamed to `group_by`.:DeprecationWarning",
+  "ignore:`map` is deprecated. It has been renamed to `map_batches`.:DeprecationWarning",
 ]
 testpaths = ['tests', 'src']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
-  "ignore::DeprecationWarning:pkg_resources.*:",
+  "ignore::DeprecationWarning:pkg_resources",
 ]
 testpaths = ['tests', 'src']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,8 @@ doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
   "ignore:Both a distance column and experiment.*:UserWarning",
-  "ignore:pkg_resources is deprecated.*:DeprecationWarning"]
+  "ignore:pkg_resources is deprecated.*:DeprecationWarning",
+]
 testpaths = ['tests', 'src']
 
 [tool.setuptools-git-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
+  "ignore::UserWarning",
   "ignore::DeprecationWarning",
   "ignore::DeprecationWarning:pkg_resources",
   "ignore::DeprecationWarning:pkg_resources.*:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
-filterwarnings = ['ignore::DeprecationWarning:pkg_resources.*:']
+filterwarnings = "error"
 testpaths = ['tests', 'src']
 
 [tool.setuptools-git-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
   "ignore:Both a distance column and experiment.*:UserWarning",
-  "ignore::DeprecationWarning",
 ]
 testpaths = ['tests', 'src']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ addopts = "-ra -l --tb=long --doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 filterwarnings = [
   "error",
-  "ignore::DeprecationWarning:pkg_resources",
+  "ignore::DeprecationWarning:pkg_resources.*:",
 ]
 testpaths = ['tests', 'src']
 


### PR DESCRIPTION
Running our tests raises several warnings. They were just ignored before, but now we will treat each unexpected warning as an error.

As there are already some warnings raised that need to be worked on, I have created ignore-exceptions for these cases. Getting rid of these ignores can be worked on in separate PRs which then can remove the respective ignore line from the pyproject.toml 

These are the added exceptions
https://github.com/aeye-lab/pymovements/blob/ec11568ff43ba2af64ccbf554ed86024055ea34a/pyproject.toml#L132-L142