### PR TITLE
ci: don't setup python twice in github workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python }}
       - name: Install tox
         run: python -m pip install tox
       - name: Setup test environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,16 +33,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install base python for tox
+      - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install tox
         run: python -m pip install tox
-      - name: Install python for test
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
       - name: Setup test environment
         run: tox -vv --notest -e ${{ matrix.tox_env }}
       - name: Run test
@@ -79,16 +75,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install base python for tox
+      - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install tox
         run: python -m pip install tox-min-req
-      - name: Install python for test
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
       - name: Setup test environment
         run: MIN_REQ=1 tox -vv --notest -e py39
       - name: Run test


### PR DESCRIPTION
## Description

It seems that python is setup twice without being necessary.

## Implemented changes

Just setup python once instead of twice.

