### PR TITLE
fix: SchemaFieldNotFoundError When Loading Preprocessed Data

### DIFF
--- a/src/pymovements/dataset/dataset_files.py
+++ b/src/pymovements/dataset/dataset_files.py
@@ -213,7 +213,8 @@ def load_gaze_files(
             custom_read_kwargs=definition.custom_read_kwargs,
         )
 
-        gaze_data = gaze_data.rename(definition.column_map)
+        if not preprocessed:
+            gaze_data = gaze_data.rename(definition.column_map)
 
         # Add fileinfo columns to dataframe.
         gaze_data = add_fileinfo(

--- a/tests/functional/dataset_processing_test.py
+++ b/tests/functional/dataset_processing_test.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2023 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Test basic preprocessing on various datasets."""
+
+import shutil
+import pytest
+
+import pymovements as pm
+
+
+@pytest.fixture(
+    name='datasets',
+    params=[
+        'csv_monocular',
+        'csv_binocular',
+        'ipc_monocular',
+        'ipc_binocular',
+        'hbn',
+        'sbsat',
+        'gaze_on_faces',
+        'gazebase',
+        'gazebase_vr',
+        'judo1000',
+    ],
+)
+def fixture_dataset_init_kwargs(request):
+    init_param_dict = {
+        'csv_monocular':pm.dataset.DatasetDefinition(
+            time_column='time',
+            pixel_columns=['x_left_pix', 'y_left_pix'],
+            experiment=pm.Experiment(1024, 768, 38, 30, 60, 'center', 1000),
+            filename_format='monocular_example.csv',
+        ),
+        'csv_binocular': pm.dataset.DatasetDefinition(
+            filename_format='binocular_example.csv',
+            time_column='time',
+            pixel_columns=['x_left_pix', 'y_left_pix', 'x_right_pix', 'y_right_pix'],
+            position_columns=['x_left_pos', 'y_left_pos', 'x_right_pos', 'y_right_pos'],
+            experiment=pm.Experiment(1024, 768, 38, 30, 60, 'center', 1000),
+        ),
+        'ipc_monocular': pm.dataset.DatasetDefinition(
+            filename_format='monocular_example.feather',
+            experiment=pm.Experiment(1024, 768, 38, 30, 60, 'center', 1000),
+        ),
+        'ipc_binocular': pm.dataset.DatasetDefinition(
+            filename_format='binocular_example.feather',
+            experiment=pm.Experiment(1024, 768, 38, 30, 60, 'center', 1000),
+        ),
+        'hbn': pm.datasets.HBN(
+            filename_format='hbn_example.csv',
+            filename_format_dtypes={},
+            trial_columns=None
+        ),
+        'sbsat': pm.datasets.SBSAT(
+            filename_format='sbsat_example.csv',
+            filename_format_dtypes={},
+
+        ),
+        'gaze_on_faces': pm.datasets.GazeOnFaces(
+            filename_format='gaze_on_faces_example.csv',
+            filename_format_dtypes={},
+            trial_columns=None
+        ),
+        'gazebase': pm.datasets.GazeBase(
+            filename_format='gazebase_example.csv',
+            filename_format_dtypes={},
+            trial_columns=None
+        ),
+        'gazebase_vr': pm.datasets.GazeBaseVR(
+            filename_format='gazebase_vr_example.csv',
+            filename_format_dtypes={},
+            trial_columns=None,
+        ),
+        'judo1000': pm.datasets.JuDo1000(
+            filename_format='judo1000_example.csv',
+            filename_format_dtypes={},
+            trial_columns=['trial_id'],
+        )
+
+    }
+    yield pm.dataset.Dataset(
+        definition=init_param_dict[request.param],
+        path=pm.dataset.DatasetPaths(
+            root='tests',
+            dataset='.',
+            raw='files',
+        ),
+    )
+
+
+def test_dataset_save_load_preprocessed(datasets):
+    dataset = datasets
+    dataset.load()
+
+    if 'pixel' in dataset.gaze[0].frame.columns:
+        dataset.pix2deg()
+
+    dataset.pos2vel()
+    dataset.save()
+    dataset.load(preprocessed=True)
+
+    shutil.rmtree(dataset.paths.preprocessed)

--- a/tests/functional/dataset_processing_test.py
+++ b/tests/functional/dataset_processing_test.py
@@ -115,5 +115,3 @@ def test_dataset_save_load_preprocessed(datasets):
     dataset.pos2vel()
     dataset.save()
     dataset.load(preprocessed=True)
-
-    shutil.rmtree(dataset.paths.preprocessed)


### PR DESCRIPTION
Fixes #607

Changes:

- Only rename input columns by `column_map` when loading raw data
- Test for loading preprocessed dataset. 

Working with the example files currently present in `tests/files` I had to adjust some attributes of the pupil datasets `DatasetDefinition`.