### PR TITLE
build: raise minor version on breaking changes only

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,7 +27,7 @@ exclude-labels:
   - skip changelog
 
 exclude-contributors:
-  - pre-commit-ci[bot]
+  - pre-commit-ci
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,8 +3,6 @@ name-template: pymovements v$RESOLVED_VERSION
 version-resolver:
   minor:
     labels:
-      - deprecation
-      - enhancement
       - breaking
   default: patch
 
@@ -29,7 +27,7 @@ exclude-labels:
   - skip changelog
 
 exclude-contributors:
-  - pre-commit-ci
+  - pre-commit-ci[bot]
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'


### PR DESCRIPTION
Until we hit v1.0.0 this is probably the best way of semantic versioning
