### PR TITLE
ci: don't fail pytest on incomplete coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ commands =
         --cov-report term-missing \
         --cov-report html:htmlcov \
         --cov-report xml \
-        --cov-fail-under 100 \
         {posargs:.}
 
 


### PR DESCRIPTION
# Problem

Currently, if a PR doesn't achieve full test coverage, all pytest workers will fail. This is not nice, as pytest workers failing should signal errors in tests not in coverage. We already have codecov workers which fail on not meeting 100% coverage.

# Solution

I have added the codecov checks to the required checks that each PR must pass. This way we still guarantee that PRs won't be merged with incomplete test coverage, but pytest workers also won't get red.

