### PR TITLE
ci: avoid invocation error in integration test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands =
         -v \
         --tb=long \
         tests/integration
-        {posargs:.}
+        {posargs}
 
 
 [testenv:pylint]


### PR DESCRIPTION
dot is not needed