### PR TITLE
ci: update pydocstyle ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,7 +114,7 @@ repos:
         files: ^src/
         args:
           [
-            '--ignore=D107,D213',
+            '--ignore=D107,D203,D213,D413',
           ]
     -   id: pydocstyle
         files: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,7 +114,7 @@ repos:
         files: ^src/
         args:
           [
-            '--ignore=D107',
+            '--ignore=D107,D213',
           ]
     -   id: pydocstyle
         files: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,11 +112,15 @@ repos:
     hooks:
     -   id: pydocstyle
         files: ^src/
+        args:
+          [
+            '--ignore=D107',
+          ]
     -   id: pydocstyle
         files: ^tests/
         args:
           [
-            '--ignore=D103,D213',
+            '--ignore=D103,D107,D213',
           ]
 -   repo: https://github.com/PyCQA/pylint
     rev: v3.0.3


### PR DESCRIPTION
some error codes were incompatible with *pydoclint*.

added the following ignores:

- src
    - D107: Missing docstring in __init__  (pydoclint does not allow for init docstrings)
    - D203: 1 blank line required before class docstring
    - D213: Multi-line docstring summary should start at the second line
    - D413: Missing blank line after last section
- test
    - D107: Missing docstring in __init__  (pydoclint does not allow for init docstrings)