### PR TITLE
docs: workaround ci failure by pinning nbconvert<7.14

### DIFF
--- a/docs/source/tutorials/detecting-events.ipynb
+++ b/docs/source/tutorials/detecting-events.ipynb
@@ -195,6 +195,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "11e1f88e",
+   "metadata": {},
+   "source": [
+    " "
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c448ef0d",
    "metadata": {},
    "source": [

--- a/docs/source/tutorials/detecting-events.ipynb
+++ b/docs/source/tutorials/detecting-events.ipynb
@@ -195,14 +195,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11e1f88e",
-   "metadata": {},
-   "source": [
-    " "
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "c448ef0d",
    "metadata": {},
    "source": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ dynamic = ["version"]
 [project.optional-dependencies]
 docs = [
   "ipykernel>=6.13.0",
-  "nbconvert<7.14",
-  "nbsphinx>=0.8.8,<0.9",
+  "nbconvert>=7.0.0,<7.14",
+  "nbsphinx>=0.8.8,<=0.9.4",
   "pandoc",
   "pybtex",
   "pydata-sphinx-theme>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dynamic = ["version"]
 docs = [
   "ipykernel>=6.13.0",
   "nbconvert>=7.0.0,<7.14",
-  "nbsphinx>=0.8.8,<=0.9.4",
+  "nbsphinx>=0.8.8,<0.9.4",
   "pandoc",
   "pybtex",
   "pydata-sphinx-theme>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 docs = [
   "ipykernel>=6.13.0",
-  "nbsphinx>=0.8.8",
+  "nbsphinx>=0.8.8,<0.9",
   "pandoc",
   "pybtex",
   "pydata-sphinx-theme>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 docs = [
   "ipykernel>=6.13.0",
+  "nbconvert<7.14",
   "nbsphinx>=0.8.8,<0.9",
   "pandoc",
   "pybtex",


### PR DESCRIPTION
Recently a failure in our CI popped up with messages like these:

```
/home/runner/work/pymovements/pymovements/docs/source/tutorials/detecting-events.ipynb:163: ERROR: Content block expected for the "raw" directive; none found.
```