### PR TITLE
feat!: rename GazeDataFrame.copy() to clone()

### DIFF
--- a/src/pymovements/dataset/dataset_files.py
+++ b/src/pymovements/dataset/dataset_files.py
@@ -482,7 +482,7 @@ def save_preprocessed(
     disable_progressbar = not verbose
 
     for file_id, gaze_df in enumerate(tqdm(gaze, disable=disable_progressbar)):
-        gaze_df = gaze_df.copy()
+        gaze_df = gaze_df.clone()
 
         raw_filepath = paths.raw / Path(fileinfo[file_id, 'filepath'])
         preprocessed_filepath = paths.get_preprocessed_filepath(

--- a/src/pymovements/gaze/gaze_dataframe.py
+++ b/src/pymovements/gaze/gaze_dataframe.py
@@ -659,7 +659,7 @@ class GazeDataFrame:
                 ],
             ).drop(input_col)
 
-    def copy(self) -> GazeDataFrame:
+    def clone(self) -> GazeDataFrame:
         """Return a copy of the GazeDataFrame.
 
         Returns

--- a/tests/unit/gaze/gaze_dataframe_test.py
+++ b/tests/unit/gaze/gaze_dataframe_test.py
@@ -173,7 +173,7 @@ def test_gaze_dataframe_copy_with_experiment():
         position_columns=['x', 'y'],
     )
 
-    gaze_copy = gaze.copy()
+    gaze_copy = gaze.clone()
 
     # We want to have separate dataframes but with the exact same data.
     assert gaze.frame is not gaze_copy.frame
@@ -197,7 +197,7 @@ def test_gaze_dataframe_copy_no_experiment():
         position_columns=['x', 'y'],
     )
 
-    gaze_copy = gaze.copy()
+    gaze_copy = gaze.clone()
 
     # We want to have separate dataframes but with the exact same data.
     assert gaze.frame is not gaze_copy.frame

--- a/tests/unit/gaze/gaze_dataframe_test.py
+++ b/tests/unit/gaze/gaze_dataframe_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 The pymovements Project Authors
+# Copyright (c) 2023-2024 The pymovements Project Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We discussed this already in November when I added this function, but I forgot to do this apparently.

I guess nobody started to use this method in the meantime, so I would just rename it without deprecation