### PR TITLE
feat: add trial_columns to EventDataFrame

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "pandas>=1.2.0,<3",
   "polars>=0.20.1,<0.20.3",
   "pyarrow>=11.0.0,<16",
-  "pyopenssl>=16.0.0,<24.0.0",
+  "pyopenssl>=16.0.0,<25.0.0",
   "scipy>=1.8.0,<2",
   "tqdm>=4.27.0,<5"
 ]

--- a/src/pymovements/events/frame.py
+++ b/src/pymovements/events/frame.py
@@ -119,6 +119,10 @@ class EventDataFrame:
                     'onset': pl.Series(onsets, dtype=pl.Int64),
                     'offset': pl.Series(offsets, dtype=pl.Int64),
                 }
+
+                if trials is not None:
+                    data_dict['trial'] = pl.Series('trial', trials)
+
             else:
                 data_dict = {
                     'name': pl.Series([], dtype=pl.Utf8),

--- a/src/pymovements/events/frame.py
+++ b/src/pymovements/events/frame.py
@@ -72,6 +72,8 @@ class EventDataFrame:
             data = self._add_minimal_schema_columns(data)
             data_dict = data.to_dict()
 
+            self.trial_columns = None
+
             self._additional_columns = [
                 column_name for column_name in data_dict.keys()
                 if column_name not in self._minimal_schema
@@ -111,6 +113,8 @@ class EventDataFrame:
                     'onset': pl.Series([], dtype=pl.Int64),
                     'offset': pl.Series([], dtype=pl.Int64),
                 }
+
+            self.trial_columns = None
 
         self.frame = pl.DataFrame(data=data_dict, schema_overrides=self._minimal_schema)
         if 'duration' not in self.frame.columns:

--- a/src/pymovements/events/frame.py
+++ b/src/pymovements/events/frame.py
@@ -121,7 +121,11 @@ class EventDataFrame:
                 }
 
                 if trials is not None:
-                    data_dict['trial'] = pl.Series('trial', trials)
+                    # Ensure that trial column is at the beginning of the dictionary.
+                    data_dict = {'trial': pl.Series('trial', trials), **data_dict}
+                    self.trial_columns = ['trial']
+                else:
+                    self.trial_columns = None
 
             else:
                 data_dict = {
@@ -129,8 +133,7 @@ class EventDataFrame:
                     'onset': pl.Series([], dtype=pl.Int64),
                     'offset': pl.Series([], dtype=pl.Int64),
                 }
-
-            self.trial_columns = None if trials is None else ['trial']
+                self.trial_columns = None
 
         self.frame = pl.DataFrame(data=data_dict, schema_overrides=self._minimal_schema)
         if 'duration' not in self.frame.columns:

--- a/src/pymovements/events/frame.py
+++ b/src/pymovements/events/frame.py
@@ -69,6 +69,8 @@ class EventDataFrame:
             trials: list[int | float | str] | np.ndarray | None = None,
             trial_columns: list[str] | str | None = None,
     ):
+        self.trial_columns: list[str] | None  # otherwise mypy gets confused.
+
         if data is not None:
             checks.check_is_mutual_exclusive(data=data, onsets=onsets)
             checks.check_is_mutual_exclusive(data=data, offsets=offsets)

--- a/src/pymovements/events/frame.py
+++ b/src/pymovements/events/frame.py
@@ -46,6 +46,10 @@ class EventDataFrame:
         List of onsets. (default: None)
     offsets: list[int] | np.ndarray | None
         List of offsets. (default: None)
+    trials: list[int | float | str] | np.ndarray | None
+        List of trial identifiers. (default: None)
+    trial_columns: list[str] | str | None
+        List of trial columns in passed dataframe.
 
     Raises
     ------
@@ -62,17 +66,23 @@ class EventDataFrame:
             name: str | list[str] | None = None,
             onsets: list[int] | np.ndarray | None = None,
             offsets: list[int] | np.ndarray | None = None,
+            trials: list[int | float | str] | np.ndarray | None = None,
+            trial_columns: list[str] | str | None = None,
     ):
         if data is not None:
             checks.check_is_mutual_exclusive(data=data, onsets=onsets)
             checks.check_is_mutual_exclusive(data=data, offsets=offsets)
             checks.check_is_mutual_exclusive(data=data, name=name)
+            checks.check_is_mutual_exclusive(data=data, name=trials)
 
             data = data.clone()
             data = self._add_minimal_schema_columns(data)
             data_dict = data.to_dict()
 
-            self.trial_columns = None
+            if isinstance(trial_columns, str):
+                self.trial_columns = [trial_columns]
+            else:
+                self.trial_columns = trial_columns
 
             self._additional_columns = [
                 column_name for column_name in data_dict.keys()
@@ -114,7 +124,7 @@ class EventDataFrame:
                     'offset': pl.Series([], dtype=pl.Int64),
                 }
 
-            self.trial_columns = None
+            self.trial_columns = None if trials is None else ['trial']
 
         self.frame = pl.DataFrame(data=data_dict, schema_overrides=self._minimal_schema)
         if 'duration' not in self.frame.columns:

--- a/tests/unit/events/frame_test.py
+++ b/tests/unit/events/frame_test.py
@@ -182,22 +182,53 @@ def test_event_dataframe_init_expected(args, kwargs, expected_df_data, expected_
 
 
 @pytest.mark.parametrize(
-    ('args', 'kwargs', 'expected_trial_column_list'),
+    ('kwargs', 'expected_trial_column_list'),
     [
         pytest.param(
-            [pl.DataFrame()], {},
+            {'data': pl.DataFrame()},
             None,
-            id='dataframe_arg_no_kwargs',
+            id='empty_df_no_trial_columns',
         ),
         pytest.param(
-            [], {'onsets': [0], 'offsets': [1]},
+            {'onsets': [0], 'offsets': [1]},
             None,
-            id='no_arg_dict_with_single_event_kwarg',
+            id='single_row_no_trial_columns',
+        ),
+        pytest.param(
+            {'onsets': [0], 'offsets': [1], 'trials': None},
+            None,
+            id='single_row_trials_list',
+        ),
+        pytest.param(
+            {'onsets': [0], 'offsets': [1], 'trials': ['A']},
+            ['trial'],
+            id='single_row_trials_list',
+        ),
+        pytest.param(
+            {'data': pl.DataFrame({'onset': [0], 'offset': [1], 'trial': ['A']})},
+            None,
+            id='single_row_trial_column_not_specified',
+        ),
+        pytest.param(
+            {
+                'data': pl.DataFrame({'onset': [0], 'offset': [1], 'trial': ['A']}),
+                'trial_columns': ['trial'],
+            },
+            ['trial'],
+            id='single_row_trial_column_specified',
+        ),
+        pytest.param(
+            {
+                'data': pl.DataFrame({'onset': [0], 'offset': [1], 'trial': ['A']}),
+                'trial_columns': 'trial',
+            },
+            ['trial'],
+            id='single_row_trial_column_str',
         ),
     ],
 )
-def test_event_dataframe_init_expected_trial_column_list(args, kwargs, expected_trial_column_list):
-    events = pm.EventDataFrame(*args, **kwargs)
+def test_event_dataframe_init_expected_trial_column_list(kwargs, expected_trial_column_list):
+    events = pm.EventDataFrame(**kwargs)
 
     assert events.trial_columns == expected_trial_column_list
 

--- a/tests/unit/events/frame_test.py
+++ b/tests/unit/events/frame_test.py
@@ -273,6 +273,36 @@ def test_event_dataframe_init_expected_trial_column_list(kwargs, expected_trial_
             pl.DataFrame({'group': [1], 'trial': ['C']}),
             id='single_row_two_trial_columns',
         ),
+        pytest.param(
+            {
+                'data': pl.DataFrame(
+                    {'onset': [0, 2], 'offset': [1, 3], 'trial': [1, 1]},
+                ),
+                'trial_columns': 'trial',
+            },
+            pl.DataFrame({'trial': [1, 1]}),
+            id='two_rows_one_trial',
+        ),
+        pytest.param(
+            {
+                'data': pl.DataFrame(
+                    {'onset': [0, 2], 'offset': [1, 3], 'trial': [1, 2]},
+                ),
+                'trial_columns': 'trial',
+            },
+            pl.DataFrame({'trial': [1, 2]}),
+            id='two_rows_one_trial',
+        ),
+        pytest.param(
+            {
+                'data': pl.DataFrame(
+                    {'onset': [0, 2], 'offset': [1, 3], 'trial': 1},
+                ),
+                'trial_columns': 'trial',
+            },
+            pl.DataFrame({'trial': [1, 1]}),
+            id='two_rows_plain_trial',
+        ),
     ],
 )
 def test_event_dataframe_init_expected_trial_column_data(kwargs, expected_trial_column_data):

--- a/tests/unit/events/frame_test.py
+++ b/tests/unit/events/frame_test.py
@@ -182,6 +182,53 @@ def test_event_dataframe_init_expected(args, kwargs, expected_df_data, expected_
 
 
 @pytest.mark.parametrize(
+    ('args', 'kwargs', 'expected_df'),
+    [
+        pytest.param(
+            [], {'onsets': [0], 'offsets': [1]},
+            pl.DataFrame({'name': [''], 'onset': [0], 'offset': [1], 'duration': [1]}),
+            id='no_arg_lists_with_single_event_kwarg',
+        ),
+        pytest.param(
+            [pl.DataFrame()], {},
+            pl.DataFrame({}),
+            id='dataframe_arg_no_kwargs',
+        ),
+        pytest.param(
+            [], {'name': 'bar', 'onsets': [0], 'offsets': [1]},
+            pl.DataFrame({'name': ['bar'], 'onset': [0], 'offset': [1], 'duration': [1]}),
+            id='lists_with_single_named_event',
+        ),
+        pytest.param(
+            [], {'name': 'bar', 'onsets': [0, 2], 'offsets': [1, 3]},
+            pl.DataFrame(
+                {'name': ['bar', 'bar'], 'onset': [0, 2], 'offset': [1, 3], 'duration': [1, 1]},
+            ),
+            id='lists_with_two_events_same_name',
+        ),
+        pytest.param(
+            [], {'name': ['foo', 'bar'], 'onsets': [0, 2], 'offsets': [1, 4]},
+            pl.DataFrame(
+                {'name': ['foo', 'bar'], 'onset': [0, 2], 'offset': [1, 4], 'duration': [1, 2]},
+            ),
+            id='lists_with_two_differently_named_events',
+        ),
+        pytest.param(
+            [], {'name': ['foo'], 'onsets': [0], 'offsets': [1], 'trials': [1]},
+            pl.DataFrame(
+                {'trial': [1], 'name': ['foo'], 'onset': [0], 'offset': [1], 'duration': [1]},
+            ),
+            id='lists_one_event_trial_column_at_start',
+        ),
+    ],
+)
+def test_event_dataframe_init_expected_df(args, kwargs, expected_df):
+    event_df = pm.EventDataFrame(*args, **kwargs)
+
+    assert_frame_equal(event_df.frame, expected_df)
+
+
+@pytest.mark.parametrize(
     ('kwargs', 'expected_trial_column_list'),
     [
         pytest.param(

--- a/tests/unit/events/frame_test.py
+++ b/tests/unit/events/frame_test.py
@@ -219,6 +219,14 @@ def test_event_dataframe_init_expected(args, kwargs, expected_df_data, expected_
         ),
         pytest.param(
             {
+                'data': pl.DataFrame({'onset': [0], 'offset': [1], 'group': [1], 'trial': ['C']}),
+                'trial_columns': ['group', 'trial'],
+            },
+            ['group', 'trial'],
+            id='single_row_two_trial_columns',
+        ),
+        pytest.param(
+            {
                 'data': pl.DataFrame({'onset': [0], 'offset': [1], 'trial': ['A']}),
                 'trial_columns': 'trial',
             },
@@ -231,6 +239,48 @@ def test_event_dataframe_init_expected_trial_column_list(kwargs, expected_trial_
     events = pm.EventDataFrame(**kwargs)
 
     assert events.trial_columns == expected_trial_column_list
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'expected_trial_column_data'),
+    [
+        pytest.param(
+            {'onsets': [0], 'offsets': [1], 'trials': ['A']},
+            pl.Series('trial', ['A']),
+            id='single_row_trials_list',
+        ),
+        pytest.param(
+            {
+                'data': pl.DataFrame({'onset': [0], 'offset': [1], 'trial': ['C']}),
+                'trial_columns': 'trial',
+            },
+            pl.Series('trial', ['C']),
+            id='single_row_trial_column_str',
+        ),
+        pytest.param(
+            {
+                'data': pl.DataFrame({'onset': [0], 'offset': [1], 'trial': ['B']}),
+                'trial_columns': ['trial'],
+            },
+            pl.Series('trial', ['B']),
+            id='single_row_trial_column_list_single',
+        ),
+        pytest.param(
+            {
+                'data': pl.DataFrame({'onset': [0], 'offset': [1], 'group': [1], 'trial': ['C']}),
+                'trial_columns': ['group', 'trial'],
+            },
+            pl.DataFrame({'group': [1], 'trial': ['C']}),
+            id='single_row_two_trial_columns',
+        ),
+    ],
+)
+def test_event_dataframe_init_expected_trial_column_data(kwargs, expected_trial_column_data):
+    events = pm.EventDataFrame(**kwargs)
+
+    if isinstance(expected_trial_column_data, pl.Series):
+        expected_trial_column_data = pl.DataFrame(expected_trial_column_data)
+    assert_frame_equal(events.frame[events.trial_columns], expected_trial_column_data)
 
 
 def test_event_dataframe_columns_same_as_frame():

--- a/tests/unit/events/frame_test.py
+++ b/tests/unit/events/frame_test.py
@@ -181,6 +181,27 @@ def test_event_dataframe_init_expected(args, kwargs, expected_df_data, expected_
     assert_frame_equal(event_df.frame, expected_df)
 
 
+@pytest.mark.parametrize(
+    ('args', 'kwargs', 'expected_trial_column_list'),
+    [
+        pytest.param(
+            [pl.DataFrame()], {},
+            None,
+            id='dataframe_arg_no_kwargs',
+        ),
+        pytest.param(
+            [], {'onsets': [0], 'offsets': [1]},
+            None,
+            id='no_arg_dict_with_single_event_kwarg',
+        ),
+    ],
+)
+def test_event_dataframe_init_expected_trial_column_list(args, kwargs, expected_trial_column_list):
+    events = pm.EventDataFrame(*args, **kwargs)
+
+    assert events.trial_columns == expected_trial_column_list
+
+
 def test_event_dataframe_columns_same_as_frame():
     init_kwargs = {'onsets': [0], 'offsets': [1]}
     event_df = pm.EventDataFrame(**init_kwargs)


### PR DESCRIPTION
## Description

For trializing the event detection method it is nice to have info on the trial columns available in the EventDataFrame class itself.

## Implemented changes

- [x] add `trials` argument for passing a list of trial identifiers
- [x] add `trial_columns` for passing a list of columns that refer to trial identifiers
- [x] enforce trial columns to be at the start of the dataframe

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] test for correct trial column names
- [x] test for correct trial identifier data

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
