### PR TITLE
Feature/parse eyelink

### DIFF
--- a/src/pymovements/dataset/dataset_files.py
+++ b/src/pymovements/dataset/dataset_files.py
@@ -327,7 +327,7 @@ def load_gaze_file(
     elif filepath.suffix == '.feather':
         gaze_df = pl.read_ipc(filepath)
     elif filepath.suffix == '.asc':
-        gaze_df = parse_eyelink(filepath, **custom_read_kwargs)
+        gaze_df, _ = parse_eyelink(filepath, **custom_read_kwargs)
     else:
         valid_extensions = ['csv', 'tsv', 'txt', 'feather', 'asc']
         raise ValueError(

--- a/src/pymovements/gaze/io.py
+++ b/src/pymovements/gaze/io.py
@@ -268,7 +268,7 @@ def from_asc(
             raise ValueError(f"unknown pattern key '{patterns}'. Supported keys are: eyelink")
 
     # Read data.
-    gaze_data = parse_eyelink(file, patterns=patterns, schema=schema)
+    gaze_data, _ = parse_eyelink(file, patterns=patterns, schema=schema)
 
     # Create gaze data frame.
     gaze_df = GazeDataFrame(

--- a/src/pymovements/utils/parsing.py
+++ b/src/pymovements/utils/parsing.py
@@ -223,7 +223,7 @@ def parse_eyelink(
                     # each metadata pattern should only match once
                     compiled_metadata_patterns.remove(pattern)
 
-    # note sure not if this is the best way...
+    # note sure if this is the best way...
     if metadata:
         metadata['version_number'], metadata['model'] = _parse_full_version(
             metadata['version_1'], metadata['version_2'],
@@ -263,7 +263,7 @@ def _parse_full_version(version_str_1: str, version_str_2: str) -> tuple[str, st
     Returns
     -------
     tuple[str, str]
-        Version number and model as strings.
+        Version number and model as strings or unknown if it cannot be parsed.
     """
     if version_str_1 == 'EYELINK II 1' and version_str_2:
         version_pattern = re.compile(r'.*v(?P<version_number>[0-9]\.[0-9]+).*')

--- a/tests/unit/utils/parsing_test.py
+++ b/tests/unit/utils/parsing_test.py
@@ -22,13 +22,11 @@ import numpy as np
 import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
-from unittest import TestCase
 
 import pymovements as pm
 
 
 ASC_TEXT = r"""
-** CONVERTED FROM D:\pymovements\results\sub_1\sub_1.edf using edfapi 4.2.1 Win32  EyeLink Dataviewer Sub ComponentApr 12 2021 on Fri Mar 10 18:07:57 2023
 ** DATE: Wed Mar  8 09:25:20 2023
 ** TYPE: EDF_FILE BINARY EVENT SAMPLE TAGGED
 ** VERSION: EYELINK II 1
@@ -214,6 +212,19 @@ def test_parse_eyelink_raises_value_error(tmp_path, patterns):
             'EyeLink I',
             id='eye_link_I',
         ),
+        pytest.param(
+            '** VERSION: nothing\n',
+            'unknown',
+            'unknown',
+            id='unknown_version_1',
+        ),
+        pytest.param(
+            '** VERSION: EYELINK II 1\n'
+            '** EYELINK II CL Feb  1 2018 (EyeLink Portable Duo)',
+            'unknown',
+            'unknown',
+            id='unknown_version_2',
+        ),
     ],
 )
 def test_parse_eyelink_version(tmp_path, metadata, expected_version, expected_model):
@@ -227,12 +238,13 @@ def test_parse_eyelink_version(tmp_path, metadata, expected_version, expected_mo
     assert metadata['version_number'] == expected_version
     assert metadata['model'] == expected_model
 
+
 @pytest.mark.parametrize(
     'metadata, expected_msg',
     [
         pytest.param(
             '',
-            f'No metadata found. Please check the file for errors.',
+            'No metadata found. Please check the file for errors.',
             id='eye_link_no_metadata',
         ),
     ],
@@ -249,4 +261,3 @@ def test_no_metadata_warning(tmp_path, metadata, expected_msg):
     msg = info.value.args[0]
 
     assert msg == expected_msg
-


### PR DESCRIPTION
## Description

Partially fixes issue #510 

## Implemented changes

binocular is not yet supported

- [x] parses datetime, version_number, model, SR, tracked eye, filter and tracking from eyelink asc file
- [x] For the version and the model: if those cannot be parsed correctly, their value will be 'unknown'
- [x] raise Warning if no metadata at all is found

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
