### PR TITLE
fix: update checksum of PoTeC resource file

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -36,11 +36,11 @@
 }
 
 @misc{potec,
-    author = {Jäger, Lena A. and Haller, Patrick and Jakobi, Deborah Noemie},
-    title = {{Potsdam Textbook Corpus}},
-    year = {2021},
-    pages = {},
-    doi = {10.17605/OSF.IO/DN5HP},
+    url = {\url{https://github.com/DiLi-Lab/PoTeC}},
+    author = {Jakobi, Deborah N. and Kern, Thomas and Reich, David R. and Haller, Patrick and J\"ager, Lena A.},
+    title = {{PoTeC}: A {German} Naturalistic Eye-tracking-while-reading Corpus},
+    year = {2024},
+    note = {under review},
 }
 
 @article{SalvucciGoldberg2000,

--- a/src/pymovements/datasets/gaze_graph.py
+++ b/src/pymovements/datasets/gaze_graph.py
@@ -88,7 +88,7 @@ class GazeGraph(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("GazeGraph", path='data/GazeGraph')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/gaze_on_faces.py
+++ b/src/pymovements/datasets/gaze_on_faces.py
@@ -86,7 +86,7 @@ class GazeOnFaces(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("GazeOnFaces", path='data/GazeOnFaces')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/gazebase.py
+++ b/src/pymovements/datasets/gazebase.py
@@ -90,7 +90,7 @@ class GazeBase(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("GazeBase", path='data/GazeBase')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/gazebasevr.py
+++ b/src/pymovements/datasets/gazebasevr.py
@@ -91,7 +91,7 @@ class GazeBaseVR(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("GazeBaseVR", path='data/GazeBaseVR')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/hbn.py
+++ b/src/pymovements/datasets/hbn.py
@@ -85,7 +85,7 @@ class HBN(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("HBN", path='data/HBN')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/judo1000.py
+++ b/src/pymovements/datasets/judo1000.py
@@ -84,7 +84,7 @@ class JuDo1000(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("JuDo1000", path='data/JuDo1000')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/potec.py
+++ b/src/pymovements/datasets/potec.py
@@ -52,7 +52,7 @@ class PoTeC(DatasetDefinition):
 
     The corpus and all the accompanying data at all
     stages of the preprocessing pipeline and all code used to preprocess the data are
-    made available via GitHub: https://github.com/DiLi-Lab/PoTeC.
+    made available via `GitHub. <https://github.com/DiLi-Lab/PoTeC>`_
 
     Attributes
     ----------

--- a/src/pymovements/datasets/potec.py
+++ b/src/pymovements/datasets/potec.py
@@ -113,7 +113,7 @@ class PoTeC(DatasetDefinition):
         {
             'resource': 'tgd9q/',
             'filename': 'PoTeC.zip',
-            'md5': '7780904bf7b18ba7d30a811174750db3',
+            'md5': 'cffd45039757c3777e2fd130e5d8a2ad',
         },
     )
 

--- a/src/pymovements/datasets/potec.py
+++ b/src/pymovements/datasets/potec.py
@@ -36,20 +36,23 @@ from pymovements.gaze.experiment import Experiment
 class PoTeC(DatasetDefinition):
     """PoTeC dataset :cite:p:`potec`.
 
-    The Potsdam Textbook Corpus (PoTeC) is a corpus of eye-tracking-while-reading data where
-    participants (N=75) read a series of German short texts taken from college level textbooks
-    of physics and biology. The experiments were conducted within a 2x2 fully-crossed factorial
-    design with the reader’s expertise (advanced vs beginner) and major (physics vs biology) as
-    factors. Reading comprehension was assessed using text comprehension questions. Moreover,
-    background questions that required additional knowledge beyond the presented text tested the
-    general domain knowledge.
-    The repository contains the eye-movement data (1000 Hz, right eye monocular) as well as the
-    stimulus text data     with extensive linguistic feature annotations at the sub-lexical,
-    lexical und supra-lexical     level. Therefore, the PoTeC is ideal for studying cognitive
-    processes related to sentence     comprehension at all linguistic levels (e.g. lexical,
-    syntactic, discourse) as well as higher-level text comprehension.
+    The Potsdam Textbook Corpus (PoTeC) is a naturalistic eye-tracking-while-reading
+    corpus containing data from 75 participants reading 12 scientific texts.
+    PoTeC is the first naturalistic eye-tracking-while-reading corpus that contains
+    eye-movements from domain-experts as well as novices in a within-participant
+    manipulation: It is based on a 2×2×2 fully-crossed factorial design which includes
+    the participants' level of study and the participants' discipline of study as
+    between-subject factors and the text domain as a within-subject factor. The
+    participants' reading comprehension was assessed by a series of text comprehension
+    questions and their domain knowledge was tested by text-independent
+    background questions for each of the texts. The materials are annotated for a
+    variety of linguistic features at different levels. We envision PoTeC to be used
+    for a wide range of studies including but not limited to analyses of expert and
+    non-expert reading strategies.
 
-    Check the respective `repository <https://osf.io/dn5hp/>`_ for details.
+    The corpus and all the accompanying data at all
+    stages of the preprocessing pipeline and all code used to preprocess the data are
+    made available via GitHub: https://github.com/DiLi-Lab/PoTeC.
 
     Attributes
     ----------
@@ -91,7 +94,7 @@ class PoTeC(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("PoTeC", path='data/PoTeC')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/sb_sat.py
+++ b/src/pymovements/datasets/sb_sat.py
@@ -84,7 +84,7 @@ class SBSAT(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("SBSAT", path='data/SBSAT')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/toy_dataset.py
+++ b/src/pymovements/datasets/toy_dataset.py
@@ -82,7 +82,7 @@ class ToyDataset(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("ToyDataset", path='data/ToyDataset')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 

--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -82,7 +82,7 @@ class ToyDatasetEyeLink(DatasetDefinition):
     >>>
     >>> dataset = pm.Dataset("ToyDatasetEyeLink", path='data/ToyDatasetEyeLink')
 
-    Download the dataset resources resources:
+    Download the dataset resources:
 
     >>> dataset.download()# doctest: +SKIP
 


### PR DESCRIPTION
The checksum of the PoTeC resource file has changed and thus `tox -e integration` failed.

I have updated the checksum.

@theDebbister can you confirm that the zip file has changed?
I can see a revision at the beginning of the current month here: https://osf.io/tgd9q