### PR TITLE
ci: improve tox integration command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,10 +75,12 @@ deps =
     .[test]
 commands =
     pytest \
+        --ignore=src \
+        --ignore=tests/functional \
+        --ignore=tests/unit \
         -v \
         --tb=long \
-        tests/integration
-        {posargs}
+        {posargs:.}
 
 
 [testenv:pylint]


### PR DESCRIPTION
This way it is easier to run tox for a single dataset like this:

```
tox -e integration -- tests/integration/public_dataset_processing_test.py::test_public_dataset_processing[PoTeC]
```

The command should be added to the CONTRIBUTING.md (#692)