### PR TITLE
ci: remove macos documentation test builder from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
           - ubuntu-latest
           - windows-latest
     steps:


### PR DESCRIPTION
mac worker are currently taking more than two hours for this task.
this slows down productivity too much.