### PR TITLE
feature 533 - Add deg2pix

### DIFF
--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -320,6 +320,31 @@ class Dataset:
             if experiment is None.
         """
         return self.apply('pix2deg', verbose=verbose)
+    
+    def deg2pix(self, verbose: bool = True) -> Dataset:
+        """Compute gaze positions in pixel coordinates from degrees of visual angle.
+
+        This method requires a properly initialized :py:attr:`~.Dataset.experiment` attribute.
+
+        After success, the gaze dataframe is extended by the resulting dva columns.
+
+        Parameters
+        ----------
+        verbose : bool
+            If True, show progress of computation. (default: True)
+
+        Returns
+        -------
+        Dataset
+            Returns self, useful for method cascading.
+
+        Raises
+        ------
+        AttributeError
+            If `gaze` is None or there are no gaze dataframes present in the `gaze` attribute, or
+            if experiment is None.
+        """
+        return self.apply('deg2pix', verbose=verbose)
 
     def pos2acc(
             self,

--- a/src/pymovements/gaze/__init__.py
+++ b/src/pymovements/gaze/__init__.py
@@ -38,6 +38,7 @@
    pymovements.gaze.transforms.downsample
    pymovements.gaze.transforms.norm
    pymovements.gaze.transforms.pix2deg
+   pymovements.gaze.transforms.deg2pix
    pymovements.gaze.transforms.pos2acc
    pymovements.gaze.transforms.pos2vel
    pymovements.gaze.transforms.savitzky_golay
@@ -65,6 +66,7 @@
    :toctree:
 
    pymovements.gaze.transforms_numpy.pix2deg
+   pymovements.gaze.transforms_numpy.deg2pix
    pymovements.gaze.transforms_numpy.pos2acc
    pymovements.gaze.transforms_numpy.pos2vel
    pymovements.gaze.transforms_numpy.norm

--- a/src/pymovements/gaze/gaze_dataframe.py
+++ b/src/pymovements/gaze/gaze_dataframe.py
@@ -426,6 +426,15 @@ class GazeDataFrame:
                         f'{transform_method.__name__}(pixel_column="name_of_your_pixel_column"). '
                         f'Available dataframe columns are: {self.frame.columns}',
                     )
+            if transform_method.__name__ in {'deg2pix'}:
+                if 'position' not in self.frame.columns and 'position_column' not in kwargs:
+                    raise pl.exceptions.ColumnNotFoundError(
+                        "Neither is 'position' in the dataframe columns, "
+                        'nor is a position column explicitly specified. '
+                        'You can specify the position column via: '
+                        f'{transform_method.__name__}(position_column="name_of_your_position_column"). '
+                        f'Available dataframe columns are: {self.frame.columns}',
+                    )
 
             if self.trial_columns is None:
                 self.frame = self.frame.with_columns(transform_method(**kwargs))
@@ -452,6 +461,21 @@ class GazeDataFrame:
             if experiment is None.
         """
         self.transform('pix2deg')
+        
+    def deg2pix(self) -> None:
+        """Compute gaze positions in pixel position coordinates from degrees of visual angle.
+
+        This method requires a properly initialized :py:attr:`~.GazeDataFrame.experiment` attribute.
+
+        After success, the gaze dataframe is extended by the resulting dva position columns.
+
+        Raises
+        ------
+        AttributeError
+            If `gaze` is None or there are no gaze dataframes present in the `gaze` attribute, or
+            if experiment is None.
+        """
+        self.transform('deg2pix')
 
     def pos2acc(
             self,

--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -284,6 +284,89 @@ def pix2deg(
 
     return pl.concat_list(list(degree_components)).alias(position_column)
 
+@register_transform
+def deg2pix(
+        *,
+        screen_resolution: tuple[int, int],
+        screen_size: tuple[float, float],
+        distance: float | str,
+        origin: str,
+        n_components: int,
+        position_column: str = 'position',
+        pixel_column: str = 'pixel',
+) -> pl.Expr:
+    """Convert degrees of visual angle to pixel screen coordinates.
+
+    Parameters
+    ----------
+    screen_resolution: tuple[int, int]
+        Pixel screen resolution as tuple (width, height).
+    screen_size: tuple[float, float]
+        Screen size in centimeters as tuple (width, height).
+    distance: float | str
+        Must be either a scalar or a string. If a scalar is passed, it is interpreted as the
+        Eye-to-screen distance in centimeters. If a string is passed, it is interpreted as the name
+        of a column containing the Eye-to-screen distance in millimiters for each sample.
+    origin: str
+        The location of the pixel origin. Supported values: ``center``, ``lower left``. See also
+        py:func:`~pymovements.gaze.transform.center_origin` for more information.
+    n_components: int
+        Number of components in input column.
+    position_column: str
+        The input position column name. (default: 'position')
+    pixel_column: str
+        The output pixel column name. (default: 'pixel')
+
+    Returns
+    -------
+    pl.Expr
+        The respective polars expression.
+    """
+    _check_screen_resolution(screen_resolution)
+    _check_screen_size(screen_size)
+
+    if isinstance(distance, (float, int)):
+        _check_distance(distance)
+        distance_series = pl.lit(distance)
+    elif isinstance(distance, str):
+        # True division by 10 is needed to convert distance from mm to cm
+        distance_series = pl.col(distance).truediv(10)
+    else:
+        raise TypeError(
+            f'`distance` must be of type `float`, `int` or `str`, but is of type'
+            f'`{type(distance).__name__}`',
+        )
+    
+    distance_pixels = pl.concat_list([
+        distance_series.mul(screen_resolution[component % 2] / screen_size[component % 2])
+        for component in range(n_components)
+    ])
+        
+    pixel_components = [
+            pl.col(position_column).list.get(component).radians().tan()*
+        distance_pixels.list.get(component)
+        for component in range(n_components)
+    ]
+
+    if origin == 'center':
+        origin_offset = (0.0, 0.0)
+    elif origin == 'lower left':
+        origin_offset = ((screen_resolution[0] - 1) / 2, (screen_resolution[1] - 1) / 2)
+    else:
+        supported_origins = ['center', 'lower left']
+        raise ValueError(
+            f'value `{origin}` for argument `origin` is invalid. '
+            f' Valid values are: {supported_origins}',
+        )
+
+    centered_pixels = pl.concat_list(
+        [
+            pixel_components[component] + origin_offset[component % 2]
+            for component in range(n_components)
+        ],
+    )
+    return centered_pixels.alias(pixel_column)
+
 
 def _check_distance(distance: float) -> None:
     """Check if all screen values are scalars and are greather than zero.

--- a/tests/unit/gaze/transforms/deg2pix_test.py
+++ b/tests/unit/gaze/transforms/deg2pix_test.py
@@ -282,7 +282,7 @@ def test_deg2pix_init_raises_error(kwargs, exception, msg_substrings):
             },
             pl.Series('ccc', [0], pl.Float64),
             pl.exceptions.ColumnNotFoundError,
-            ('aaa',),
+            ('bbb',),
             id='df_missing_column_raises_column_not_found_error',
         ),
     ],
@@ -370,7 +370,7 @@ def test_deg2pix_raises_error(kwargs, series, exception, msg_substrings):
                 'n_components': 2,
             },
             pl.Series('position', [[-44.7120, 45]], pl.List(pl.Float64)),
-            pl.Series('pixel', [[0, 100 - 0.5]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0.000145, 100 - 0.5]], pl.List(pl.Float64)),
             id='isosceles_triangle_origin_lowerleft_returns_45',
         ),
         pytest.param(
@@ -384,7 +384,7 @@ def test_deg2pix_raises_error(kwargs, series, exception, msg_substrings):
                 'n_components': 2,
             },
             pl.Series('position', [[-44.7120, -45]], pl.List(pl.Float64)),
-            pl.Series('pixel', [[0, -0.5]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0.000145, -0.5]], pl.List(pl.Float64)),
             id='isosceles_triangle_left_origin_lowerleft_returns_neg45',
         ),
         pytest.param(

--- a/tests/unit/gaze/transforms/deg2pix_test.py
+++ b/tests/unit/gaze/transforms/deg2pix_test.py
@@ -1,0 +1,647 @@
+# Copyright (c) 2022-2024 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Test pymovements.gaze.transforms.deg2pix. Based on tests for pix2deg"""
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+import pymovements as pm
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'exception', 'msg_substrings'),
+    [
+        pytest.param(
+            {
+                'screen_size': (100, 00),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('screen_resolution', 'missing'),
+            id='no_screen_resolution_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 00), 'distance': 100, 'origin': 'center',
+                'pixel_column': 'pixel', 'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('screen_size', 'missing'),
+            id='no_screen_size_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100), 'screen_size': (100, 100), 'origin': 'center',
+                'pixel_column': 'pixel', 'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('distance', 'missing'),
+            id='no_distance_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100), 'screen_size': (100, 100), 'distance': 100,
+                'pixel_column': 'pixel', 'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('origin', 'missing'),
+            id='no_origin_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': None,
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('screen_resolution must not be None'),
+            id='none_screen_resolution_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': None,
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('screen_size must not be None'),
+            id='none_screen_size_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': None,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('distance', 'None', 'float', 'int'),
+            id='none_distance_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (0, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('screen_resolution', 'must be greater than zero', '0'),
+            id='zero_screen_resolution_zero',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': 1,
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('screen_resolution', 'must be of type tuple[int, int]', 'type int'),
+            id='screen_resolution_int_scalar',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('screen_resolution must have length of 2, but is of length 3',),
+            id='screen_resolution_3-tuple',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100), 'screen_size': (0, 100), 'distance': 100,
+                'origin': 'center', 'pixel_column': 'pixel', 'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('screen_size', 'must be greater than zero', '0'),
+            id='zero_screen_size_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': 1,
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            TypeError,
+            ('screen_size', 'must be of type tuple[int, int]', 'type int'),
+            id='screen_size_int_scalar',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('screen_size must have length of 2, but is of length 3',),
+            id='screen_size_3-tuple',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100), 'screen_size': (100, 100), 'distance': 0,
+                'origin': 'center', 'n_components': 2,
+                'pixel_column': 'pixel', 'position_column': 'position',
+            },
+            ValueError,
+            ('distance', 'must be greater than zero', '0'),
+            id='zero_distance_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (-1, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('screen_resolution', 'must be greater than zero', '-1'),
+            id='negative_screen_resolution_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (-1, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('screen_size', 'must be greater than zero', '-1'),
+            id='negative_screen_size_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': -1,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('distance', 'must be greater than zero', '-1'),
+            id='negative_distance_raises_type_error',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'foobar',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            ValueError,
+            ('origin', 'invalid', 'foobar', 'valid', 'center', 'lower left'),
+            id='invalid_origin_raises_value_error',
+        ),
+    ],
+)
+def test_deg2pix_init_raises_error(kwargs, exception, msg_substrings):
+    with pytest.raises(exception) as excinfo:
+        pm.gaze.transforms.deg2pix(**kwargs)
+
+    msg, = excinfo.value.args
+    for msg_substring in msg_substrings:
+        assert msg_substring.lower() in msg.lower()
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'series', 'exception', 'msg_substrings'),
+    [
+        pytest.param(
+            {
+                'screen_resolution': (100, 100), 'screen_size': (100, 100), 'distance': 100,
+                'origin': 'center', 'pixel_column': 'aaa', 'position_column': 'bbb',
+                'n_components': 2,
+            },
+            pl.Series('ccc', [0], pl.Float64),
+            pl.exceptions.ColumnNotFoundError,
+            ('aaa',),
+            id='df_missing_column_raises_column_not_found_error',
+        ),
+    ],
+)
+def test_deg2pix_raises_error(kwargs, series, exception, msg_substrings):
+    df = series.to_frame()
+
+    with pytest.raises(exception) as excinfo:
+        df.with_columns(
+            pm.gaze.transforms.deg2pix(**kwargs),
+        )
+
+    msg, = excinfo.value.args
+    for msg_substring in msg_substrings:
+        assert msg_substring.lower() in msg.lower()
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'series', 'expected_df'),
+    [
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 100.,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [], pl.List(pl.Float64)),
+            pl.Series('pixel', [], pl.List(pl.Float64)),
+            id='empty_series',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[0, 0]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 0]], pl.List(pl.Float64)),
+            id='zero_origin_center_returns_0',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[-26.3354, 0]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, (100 - 1) / 2]], pl.List(pl.Float64)),
+            id='center_pixel_origin_lowerleft_returns_0',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[0, 45]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 50]], pl.List(pl.Float64)),
+            id='isosceles_triangle_origin_center_returns_45',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50,
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[-44.7120, 45]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 100 - 0.5]], pl.List(pl.Float64)),
+            id='isosceles_triangle_origin_lowerleft_returns_45',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50,
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[-44.7120, -45]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, -0.5]], pl.List(pl.Float64)),
+            id='isosceles_triangle_left_origin_lowerleft_returns_neg45',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[0, 26.5650]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 50]], pl.List(pl.Float64)),
+            id='ankathet_half_origin_center_returns_26.565',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[-26.3354, 26.5650]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 100 - 0.5]], pl.List(pl.Float64)),
+            id='ankathet_half_origin_lowerleft_returns_26.565',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50 / np.sqrt(3),
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[0, 60]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 50]], pl.List(pl.Float64)),
+            id='ankathet_sqrt3_origin_center_returns_60',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50 / np.sqrt(3),
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[-59.75, 60]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 100 - 0.5]], pl.List(pl.Float64)),
+            id='ankathet_sqrt3_origin_lowerleft_returns_60',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50 * np.sqrt(3),
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[0, 30]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[0, 50]], pl.List(pl.Float64)),
+            id='opposite_sqrt3_origin_center_returns_30',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50 * np.sqrt(3),
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[-30, 30]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[-0.5, 100 - 0.5]], pl.List(pl.Float64)),
+            id='opposite_sqrt3_origin_lowerleft_returns_30',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 200),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[45, 26.5650]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[100, 100]], pl.List(pl.Float64)),
+            id='screen_resolution_different_values',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 200),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            pl.Series('position', [[45, 63.4349]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[100, 100]], pl.List(pl.Float64)),
+            id='screen_size_different_values',
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    'distance_as_column',
+    [
+        pytest.param(True, id='column_distance'),
+        pytest.param(False, id='scalar_distance'),
+    ],
+)
+def test_deg2pix_returns(kwargs, series, expected_df, distance_as_column):
+    df = series.to_frame().clone()
+    kwargs = kwargs.copy()
+
+    # Decide whether to pass distance as column or scalar
+    if distance_as_column:
+
+        # unit of distance values has to be in mm when passing as column
+        distance_value = kwargs['distance'] * 10
+
+        df = df.with_columns(
+            pl.Series('distance', [distance_value], pl.Float64),
+        )
+
+        kwargs['distance'] = 'distance'
+
+    result_df = df.select(
+        pm.gaze.transforms.deg2pix(**kwargs),
+    )
+    assert_frame_equal(result_df, expected_df.to_frame(), atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'data', 'expected_df'),
+    [
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            {
+                'position': [[0., 0.], [0., 0.], [0., 0.]],
+                'distance': [100., 100., 100.],
+            },
+            pl.Series('pixel', [[0., 0.], [0., 0.], [0., 0.]], pl.List(pl.Float64)),
+            id='origin_center_constant_distance_and_position_returns_constant_pixel',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            {
+                'position': [[0., 0.], [0., 0.], [0., 0.]],
+                'distance': [1000., 100., 10.],
+            },
+            pl.Series('pixel', [[0., 0.], [0., 0.], [0., 0.]], pl.List(pl.Float64)),
+            id='origin_center_constant_centered_position_changing_distance_returns_constant_pixel',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            {
+                'position': [[0., 0.], [0., 0.], [0., 0.]],
+                'distance': [100., 100., 100.],
+            },
+            pl.Series('pixel', [[49.5, 49.5], [49.5, 49.5], [49.5, 49.5]], pl.List(pl.Float64)),
+            id='origin_lower_left_constant_distance_and_position_returns_constant_pixel',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'origin': 'lower left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            {
+                'position': [[0., 0.], [0., 0.], [0., 0.]],
+                'distance': [1000., 100., 10.],
+            },
+            pl.Series('pixel', [[49.5, 49.5], [49.5, 49.5], [49.5, 49.5]], pl.List(pl.Float64)),
+            id='origin_lower_left_constant_centered_position_changing_distance_returns_constant_pixel',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            {
+                'position': [[0., 63.4349], [0., 45.], [0., 26.5650]],
+                'distance': [250., 500., 1000.],
+            },
+            pl.Series(
+                'pixel', [[0., 50.], [0., 50.], [0., 50.]], pl.List(pl.Float64),
+            ),
+            id='origin_center_constant_position_centered_x_changing_distance_returns',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+            },
+            {
+                'position': [[63.4349, 0.], [45., 0.], [26.5650, 0.]],
+                'distance': [250., 500., 1000.],
+            },
+            pl.Series(
+                'pixel', [[50., 0.], [50., 0.], [50., 0.]], pl.List(pl.Float64),
+            ),
+            id='origin_center_constant_position_centered_y_changing_distance_returns',
+        ),
+    ],
+)
+def test_deg2pix_distance_as_colum_returns(kwargs, data, expected_df):
+    df = pl.DataFrame(
+        data, schema={'position': pl.List(pl.Float64), 'distance': pl.Float64},
+    )
+
+    result_df = df.select(
+        pm.gaze.transforms.deg2pix(**kwargs, distance='distance'),
+    )
+
+    assert_frame_equal(result_df, expected_df.to_frame(), atol=1e-4)

--- a/tests/unit/gaze/transforms/transforms_library_test.py
+++ b/tests/unit/gaze/transforms/transforms_library_test.py
@@ -32,6 +32,7 @@ import pymovements as pm
         pytest.param(pm.gaze.transforms.downsample, 'downsample', id='downsample'),
         pytest.param(pm.gaze.transforms.norm, 'norm', id='norm'),
         pytest.param(pm.gaze.transforms.pix2deg, 'pix2deg', id='pix2deg'),
+        pytest.param(pm.gaze.transforms.deg2pix, 'deg2pix', id='deg2pix'),
         pytest.param(pm.gaze.transforms.pos2acc, 'pos2acc', id='pos2acc'),
         pytest.param(pm.gaze.transforms.pos2vel, 'pos2vel', id='pos2vel'),
         pytest.param(pm.gaze.transforms.savitzky_golay, 'savitzky_golay', id='savitzky_golay'),


### PR DESCRIPTION
## Description

Adds `deg2pix` method. 
Fixes issue #533.

## Implemented changes

Added a deg2pix method.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

Added the same tests as in `tests/unit/gaze/transforms/pix2deg_test.py` with the following changes:
- Replaced pixel<-->position in output<-->input. 
- Added atol=1-e4 in equality assertions. @dkrako Is this okay? Alternative is to refine the input values.
- Added two digits after zero for input position value in isosceles_triangle_origin_lowerleft_returns_45 and isosceles_triangle_left_origin_lowerleft_returns_neg45.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
