### PR TITLE
docs: use smaller subset in 10 minutes tutorial

### DIFF
--- a/docs/source/tutorials/pymovements-in-10-minutes.ipynb
+++ b/docs/source/tutorials/pymovements-in-10-minutes.ipynb
@@ -217,7 +217,7 @@
    "source": [
     "subset = {\n",
     "    'text_id': 0,\n",
-    "    'page_id': range(3),\n",
+    "    'page_id': [0, 1],\n",
     "}\n",
     "dataset.load(subset=subset)\n",
     "\n",


### PR DESCRIPTION
## Description

Fixes issue #694

## Implemented changes

- [ ] decrease subset size to not exceed memory resources from readthedocs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change is or requires a documentation update

## How Has This Been Tested?

- [ ] I have checked the branch on readthedocs and the build succeeded

