### PR TITLE
ci: use macos-13 instead of macos-latest for python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - macos-13
           - macos-latest
           - ubuntu-latest
           - windows-latest
@@ -23,6 +24,15 @@ jobs:
           - py310
           - py311
           - py312
+        exclude:
+            - os: macos-latest
+              tox_env: py39
+            - os: macos-13
+              tox_env: py310
+            - os: macos-13
+              tox_env: py311
+            - os: macos-13
+              tox_env: py312
         include:
           - tox_env: py39
             python: "3.9"


### PR DESCRIPTION
fixes #723 