### PR TITLE
fix: fix ylim in tsplot for non-centered yaxis

### DIFF
--- a/src/pymovements/events/properties.py
+++ b/src/pymovements/events/properties.py
@@ -236,7 +236,7 @@ def location(
     ValueError
         If method is not one of the supported methods.
     """
-    if method not in ['mean', 'median']:
+    if method not in {'mean', 'median'}:
         raise ValueError(
             f"Method '{method}' not supported. "
             f"Please choose one of the following: ['mean', 'median'].",
@@ -252,8 +252,7 @@ def location(
 
         if method == 'mean':
             expression_component = position_component.mean()
-
-        if method == 'median':
+        else:  # by exclusion this must be median
             expression_component = position_component.median()
 
         component_expressions.append(expression_component)

--- a/src/pymovements/plotting/tsplot.py
+++ b/src/pymovements/plotting/tsplot.py
@@ -136,10 +136,11 @@ def tsplot(
     y_pad_factor = 1.1
 
     # set ylims to have zero centered y-axis (for all axes)
-    if share_y and zero_centered_yaxis:
+    # will be overwritten if share_y is False
+    if zero_centered_yaxis: 
         ylim_abs = np.nanmax(np.abs(arr))
         ylims = -ylim_abs * y_pad_factor, ylim_abs * y_pad_factor
-    elif share_y and not zero_centered_yaxis:
+    else:
         ylim_max = np.nanmax(arr)
         ylim_min = np.nanmin(arr)
         ylims = ylim_min * y_pad_factor, ylim_max * y_pad_factor

--- a/src/pymovements/plotting/tsplot.py
+++ b/src/pymovements/plotting/tsplot.py
@@ -133,22 +133,30 @@ def tsplot(
     t = np.arange(n_samples)
     xlims = t.min(), t.max()
 
+    y_pad_factor = 1.1
+
     # set ylims to have zero centered y-axis (for all axes)
     if share_y and zero_centered_yaxis:
-        y_pad_factor = 1.1
         ylim_abs = np.nanmax(np.abs(arr))
         ylims = -ylim_abs * y_pad_factor, ylim_abs * y_pad_factor
-
+    elif share_y and not zero_centered_yaxis:
+        ylim_max = np.nanmax(arr)
+        ylim_min = np.nanmin(arr)
+        ylims = ylim_min * y_pad_factor, ylim_max * y_pad_factor
+        
     for channel_id in range(n_channels):
         ax = axs[channel_id]
 
         x_channel = arr[channel_id, :]
         ax.plot(t, x_channel, color=line_color, linewidth=line_width)
 
-        if not share_y:
-            y_pad_factor = 1.1
+        if not share_y and zero_centered_yaxis:
             ylim_abs = np.nanmax(np.abs(arr[channel_id]))
             ylims = -ylim_abs * y_pad_factor, ylim_abs * y_pad_factor
+        elif not share_y and not zero_centered_yaxis:
+            ylim_max = np.nanmax(arr)
+            ylim_min = np.nanmin(arr)
+            ylims = ylim_min * y_pad_factor, ylim_max * y_pad_factor
 
         ax.set_xlim(xlims)
         ax.set_ylim(ylims)

--- a/src/pymovements/plotting/tsplot.py
+++ b/src/pymovements/plotting/tsplot.py
@@ -137,7 +137,7 @@ def tsplot(
 
     # set ylims to have zero centered y-axis (for all axes)
     # will be overwritten if share_y is False
-    if zero_centered_yaxis: 
+    if zero_centered_yaxis:
         ylim_abs = np.nanmax(np.abs(arr))
         ylims = -ylim_abs * y_pad_factor, ylim_abs * y_pad_factor
     else:

--- a/src/pymovements/plotting/tsplot.py
+++ b/src/pymovements/plotting/tsplot.py
@@ -143,7 +143,7 @@ def tsplot(
         ylim_max = np.nanmax(arr)
         ylim_min = np.nanmin(arr)
         ylims = ylim_min * y_pad_factor, ylim_max * y_pad_factor
-        
+
     for channel_id in range(n_channels):
         ax = axs[channel_id]
 

--- a/tests/unit/plotting/tsplot_test.py
+++ b/tests/unit/plotting/tsplot_test.py
@@ -68,7 +68,8 @@ def gaze_fixture():
             {
                 'zero_centered_yaxis': False,
                 'share_y': False,
-            }, id='zero_centered_yaxis_false_share_y_false'),
+            }, id='zero_centered_yaxis_false_share_y_false',
+        ),
         pytest.param({'show_yticks': False}, id='show_yticks_false'),
         pytest.param({'channels': ['x_pix']}, id='single_channel'),
         pytest.param({'channels': 'x_pix'}, id='single_channel_string'),

--- a/tests/unit/plotting/tsplot_test.py
+++ b/tests/unit/plotting/tsplot_test.py
@@ -62,6 +62,13 @@ def gaze_fixture():
     [
         pytest.param({}, id='no_kwargs'),
         pytest.param({'share_y': False}, id='share_y_false'),
+        pytest.param({'zero_centered_yaxis': True}, id='zero_centered_yaxis_true'),
+        pytest.param({'zero_centered_yaxis': False}, id='zero_centered_yaxis_false'),
+        pytest.param(
+            {
+                'zero_centered_yaxis': False,
+                'share_y': False,
+            }, id='zero_centered_yaxis_false_share_y_false'),
         pytest.param({'show_yticks': False}, id='show_yticks_false'),
         pytest.param({'channels': ['x_pix']}, id='single_channel'),
         pytest.param({'channels': 'x_pix'}, id='single_channel_string'),


### PR DESCRIPTION
pylint draw some attention to some erronuous logic in tsplot in #725 

This makes sure that ylims is really set by handling the `not zero_centered_yaxis` branch