### PR TITLE
fix: add subject ID to dataset trial columns

### DIFF
--- a/src/pymovements/datasets/gaze_graph.py
+++ b/src/pymovements/datasets/gaze_graph.py
@@ -134,7 +134,7 @@ class GazeGraph(DatasetDefinition):
         },
     )
 
-    trial_columns: list[str] = field(default_factory=lambda: ['task'])
+    trial_columns: list[str] = field(default_factory=lambda: ['subject_id', 'task'])
 
     time_column: Any = None
 

--- a/src/pymovements/datasets/hbn.py
+++ b/src/pymovements/datasets/hbn.py
@@ -130,7 +130,7 @@ class HBN(DatasetDefinition):
         },
     )
 
-    trial_columns: list[str] = field(default_factory=lambda: ['video_id'])
+    trial_columns: list[str] = field(default_factory=lambda: ['subject_id', 'video_id'])
 
     time_column: str = 'time'
 

--- a/src/pymovements/datasets/sb_sat.py
+++ b/src/pymovements/datasets/sb_sat.py
@@ -128,7 +128,13 @@ class SBSAT(DatasetDefinition):
         },
     )
 
-    trial_columns: list[str] = field(default_factory=lambda: ['book_name', 'screen_id'])
+    trial_columns: list[str] = field(
+        default_factory=lambda: [
+            'subject_id',
+            'book_name',
+            'screen_id',
+        ],
+    )
 
     time_column: str = 'time'
 

--- a/tests/functional/dataset_processing_test.py
+++ b/tests/functional/dataset_processing_test.py
@@ -77,7 +77,7 @@ def fixture_dataset_init_kwargs(request):
             time_column=pm.datasets.SBSAT().time_column,
             time_unit=pm.datasets.SBSAT().time_unit,
             filename_format_dtypes={},
-
+            trial_columns=None,
         ),
         'gaze_on_faces': pm.datasets.GazeOnFaces(
             filename_format='gaze_on_faces_example.csv',


### PR DESCRIPTION
## Description

Some dataset definitions (like SB-SAT) do not include the subject ID in `trial_columns`, while others (like PoTeC) do. There might be a reason for this that I'm unaware of, but it leads to this bug:

```py
sbsat = pm.Dataset("SBSAT", "sb-sat").download()
sbsat.pix2deg().pos2vel(method="savitzky_golay", window_length=11, degree=3)
sbsat.detect("ivt")
sbsat.detect("microsaccades")
print(sbsat.events)
```

In this example, `detect("ivt")` works just fine, but when running `detect("microsaccades")`, the added saccades will have a subject ID `null` in the event frame:

```
shape: (3_541, 7)
 ┌────────────┬───────────┬───────────┬──────────┬─────────┬─────────┬──────────┐
 │ subject_id ┆ book_name ┆ screen_id ┆ name     ┆ onset   ┆ offset  ┆ duration │
 │ ---        ┆ ---       ┆ ---       ┆ ---      ┆ ---     ┆ ---     ┆ ---      │
 │ i64        ┆ str       ┆ i64       ┆ str      ┆ i64     ┆ i64     ┆ i64      │
 ╞════════════╪═══════════╪═══════════╪══════════╪═════════╪═════════╪══════════╡
 │ 2          ┆ flytrap   ┆ 4         ┆ fixation ┆ 1754221 ┆ 1754321 ┆ 100      │
 │ 2          ┆ flytrap   ┆ 4         ┆ fixation ┆ 1758061 ┆ 1758201 ┆ 140      │
 │ 2          ┆ flytrap   ┆ 5         ┆ fixation ┆ 1802511 ┆ 1802615 ┆ 104      │
 │ null       ┆ flytrap   ┆ 1         ┆ saccade  ┆ 1612856 ┆ 1612865 ┆ 9        │
 │ …          ┆ …         ┆ …         ┆ …        ┆ …       ┆ …       ┆ …        │
 │ null       ┆ dickens   ┆ 5         ┆ saccade  ┆ 3173398 ┆ 3173472 ┆ 74       │
 │ null       ┆ dickens   ┆ 5         ┆ saccade  ┆ 3174133 ┆ 3174201 ┆ 68       │
 │ null       ┆ dickens   ┆ 5         ┆ saccade  ┆ 3174204 ┆ 3174226 ┆ 22       │
 │ null       ┆ dickens   ┆ 5         ┆ saccade  ┆ 3174332 ┆ 3174362 ┆ 30       │
 └────────────┴───────────┴───────────┴──────────┴─────────┴─────────┴──────────┘,
```

Adding `subject_id` to `trial_columns` in the dataset definition fixes this issue. However, the actual cause of the bug is here: https://github.com/aeye-lab/pymovements/blob/c83d532adec640452bcb77349b0afa6af01678f7/src/pymovements/dataset/dataset.py#L594-L599
When `add_fileinfo()` is called but the columns already exist in the event dataframe, the info (in this case the subject ID) will not be added. But maybe this should be fixed in a separate PR?

## Implemented changes

- [x] Add subject ID to `trial_columns` in SB-SAT, GazeGraph, and HBN

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

I didn't write any tests for this. Let me know if and how I should add tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
