### PR TITLE
fix: Don't override kwargs in EventGazeProcessor

### DIFF
--- a/src/pymovements/events/processing.py
+++ b/src/pymovements/events/processing.py
@@ -20,7 +20,6 @@
 """Module for event processing."""
 from __future__ import annotations
 
-import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -187,15 +186,6 @@ class EventGazeProcessor:
         property_kwargs: list[dict[str, Any]] = [
             property_kwargs for _, property_kwargs in self.event_properties
         ]
-
-        for property_id, property_expression in enumerate(property_expressions):
-            property_args = inspect.getfullargspec(property_expression).kwonlyargs
-
-            if 'position_column' in property_args:
-                property_kwargs[property_id]['position_column'] = 'position'
-
-            if 'velocity_column' in property_args:
-                property_kwargs[property_id]['velocity_column'] = 'velocity'
 
         # Each event is uniquely defined by a list of trial identifiers,
         # a name and its on- and offset.

--- a/tests/unit/events/processing_test.py
+++ b/tests/unit/events/processing_test.py
@@ -572,6 +572,54 @@ def test_event_gaze_processor_init_exceptions(args, kwargs, exception, msg_subst
             ),
             id='two_events_location_method_median',
         ),
+        pytest.param(
+            pl.from_dict(
+                {'subject_id': [1, 1], 'name': ['A', 'B'], 'onset': [0, 80], 'offset': [10, 100]},
+                schema={
+                    'subject_id': pl.Int64, 'name': pl.Utf8, 'onset': pl.Int64, 'offset': pl.Int64,
+                },
+            ),
+            pm.GazeDataFrame(
+                pl.from_dict(
+                    {
+                        'subject_id': np.ones(100),
+                        'time': np.arange(100),
+                        'x_pix': np.concatenate(
+                            [np.ones(11), np.zeros(69), 2 * np.ones(19), [200]],
+                        ),
+                        'y_pix': np.concatenate(
+                            [np.ones(11), np.zeros(69), 2 * np.ones(19), [200]],
+                        ),
+                    },
+                    schema={
+                        'subject_id': pl.Int64,
+                        'time': pl.Int64,
+                        'x_pix': pl.Float64,
+                        'y_pix': pl.Float64,
+                    },
+                ),
+                pixel_columns=['x_pix', 'y_pix'],
+            ),
+            {'event_properties': ('location', {'position_column': 'pixel'})},
+            {'identifiers': 'subject_id'},
+            pl.from_dict(
+                {
+                    'subject_id': [1, 1],
+                    'name': ['A', 'B'],
+                    'onset': [0, 80],
+                    'offset': [10, 100],
+                    'location': [[1.0, 1.0], [11.9, 11.9]],
+                },
+                schema={
+                    'subject_id': pl.Int64,
+                    'name': pl.Utf8,
+                    'onset': pl.Int64,
+                    'offset': pl.Int64,
+                    'location': pl.List(pl.Float64),
+                },
+            ),
+            id='two_events_location_position_column_pixel',
+        ),
     ],
 )
 def test_event_gaze_processor_process_correct_result(


### PR DESCRIPTION
## Description

Currently, kwargs provided by the user in `dataset.compute_event_properties()` are overridden with default values. This means that user-provided kwargs will be ignored. It is also unnecessary, because the event properties currently implemented in `pm.events.properties` already define their own default values.

Fixes issue #735.

## Implemented changes

- [x] Remove the code to override event property kwargs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

- [x] Pass kwarg `position_column="pixel"` to `location` event property

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
