### PR TITLE
fix: default traceplot cmaps

### DIFF
--- a/src/pymovements/plotting/traceplot.py
+++ b/src/pymovements/plotting/traceplot.py
@@ -60,11 +60,6 @@ DEFAULT_SEGMENTDATA: LinearSegmentedColormapType = {
         (0.5, 0.0, 0.0),
         (1.0, 0.0, 0.0),
     ],
-    'alpha': [
-        (1.0, 1.0, 1.0),
-        (1.0, 1.0, 1.0),
-        (1.0, 1.0, 1.0),
-    ],
 }
 
 
@@ -87,12 +82,6 @@ DEFAULT_SEGMENTDATA_TWOSLOPE: LinearSegmentedColormapType = {
         (0.25, 1.0, 1.0),
         (0.5, 0.0, 0.0),
         (1.0, 0.0, 0.0),
-    ],
-    'alpha': [
-        (1.0, 1.0, 1.0),
-        (1.0, 1.0, 1.0),
-        (1.0, 1.0, 1.0),
-        (1.0, 1.0, 1.0),
     ],
 }
 


### PR DESCRIPTION
## Description

Currently, calling `pm.plotting.traceplot(dataset.gaze[0])` in a notebook (even without providing any color values), raises `ValueError: data mapping points must start with x=0 and end with x=1`, because the default cmap definitions are invalid:
https://github.com/aeye-lab/pymovements/blob/5b195e18571aca39f575867aa7fc6549f15c933d/src/pymovements/plotting/traceplot.py#L63-L67

From the [matplotlib documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.LinearSegmentedColormap.html):
> Each row in the table for a given color is a sequence of x, y0, y1 tuples. In each sequence, x must increase monotonically from 0 to 1.

So to keep alpha constant, it would have to look like this:
```py
 'alpha': [
     (0.0, 1.0, 1.0),
     (1.0, 1.0, 1.0),
 ],
```
but since alpha is constant at 1.0, it can simply be removed.

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] Remove invalid cmap definition for alpha channel

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

Tested manually. This error only occurs when showing a plot in a notebook, not during testing, so it is probably very hard to test automatically.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
