### PR TITLE
as per repository types-all is deprecated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
     rev: v1.10.0
     hooks:
     -   id: mypy
-        additional_dependencies: [types-all, pandas-stubs, types-tqdm]
+        additional_dependencies: [pandas-stubs, types-tqdm]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:


### PR DESCRIPTION
types-all is deprecated and leads to pre-commit.ci failing, see e.g. #771 