### PR TITLE
hotfix: double indent linter destroyed my tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,10 +120,6 @@ repos:
           [
             '--ignore=D103,D107,D213',
           ]
--   repo: https://github.com/jkittner/double-indent
-    rev: 0.1.5
-    hooks:
-    - id: double-indent
 -   repo: https://github.com/PyCQA/pylint
     rev: v3.2.3
     hooks:


### PR DESCRIPTION
the double indent linter unfortunately locally destroyed my tests, I'll try to find a minimal example for this and fix it but until then I want to remove it. 