### PR TITLE
hotfix: specify custom_read_kwargs in copco to enable loading precomputed_events

### DIFF
--- a/src/pymovements/datasets/copco.py
+++ b/src/pymovements/datasets/copco.py
@@ -209,8 +209,10 @@ class CopCo(DatasetDefinition):
         default_factory=lambda: {
             'precomputed_events': {
                 'separator': '\t',
-                'null_values': '.',
-                'quote_char': '"',
+                'null_values': ['.', 'UNDEFINEDnull'],
+                'infer_schema_length': 100000,
+                'truncate_ragged_lines': True,
+                'decimal_comma': True,
             },
             'precomputed_reading_measures': {},
         },


### PR DESCRIPTION
since we only run integration tests on releases -- there was an unnoticed bug with loading the `precomputed_events` within the public copco dataset.