### PR TITLE
fix: correct trial columns in SB-SAT dataset

### DIFF
--- a/src/pymovements/datasets/sb_sat.py
+++ b/src/pymovements/datasets/sb_sat.py
@@ -198,7 +198,6 @@ class SBSAT(DatasetDefinition):
 
     trial_columns: list[str] = field(
         default_factory=lambda: [
-            'subject_id',
             'book_name',
             'screen_id',
         ],

--- a/tests/functional/gaze_file_processing_test.py
+++ b/tests/functional/gaze_file_processing_test.py
@@ -102,6 +102,7 @@ def fixture_gaze_init_kwargs(request):
             'time_unit': pm.datasets.SBSAT().time_unit,
             'pixel_columns': pm.datasets.SBSAT().pixel_columns,
             'experiment': pm.datasets.SBSAT().experiment,
+            'trial_columns': pm.datasets.SBSAT().trial_columns,
             **pm.datasets.SBSAT().custom_read_kwargs['gaze'],
         },
         'gaze_on_faces': {


### PR DESCRIPTION
## Description

The definition for the SB-SAT dataset included a column in the `trial_columns` field which does not exist in the data files.

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] corrected `trial_columns` field
- [x] use `trial_columns` field in `gaze_file_processing_test`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] use `trial_columns` field in `gaze_file_processing_test`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
