### PR TITLE
feat: add support for .ias files in stimulus.text.from_file()

### DIFF
--- a/src/pymovements/stimulus/text.py
+++ b/src/pymovements/stimulus/text.py
@@ -135,7 +135,7 @@ def from_file(
     if custom_read_kwargs is None:
         custom_read_kwargs = {}
 
-    valid_extensions = {'.csv', '.tsv', '.txt'}
+    valid_extensions = {'.csv', '.tsv', '.txt', '.ias'}
     if aoi_path.suffix in valid_extensions:
         stimulus_df = pl.read_csv(
             aoi_path,

--- a/tests/unit/stimulus/text_test.py
+++ b/tests/unit/stimulus/text_test.py
@@ -224,5 +224,5 @@ def test_text_stimulus_unsupported_format():
         )
     msg, = excinfo.value.args
     expected = 'unsupported file format ".pickle".Supported formats are: '\
-        '[\'.csv\', \'.tsv\', \'.txt\']'
+        '[\'.csv\', \'.ias\', \'.tsv\', \'.txt\']'
     assert msg == expected


### PR DESCRIPTION
default eyelink aoi files end in `.ias`, hence I add the file type to `from_file` for text stimulus 