### PR TITLE
docs: Add missing modules to documentation

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -11,6 +11,9 @@
     pymovements.datasets
     pymovements.events
     pymovements.gaze
+    pymovements.measure
     pymovements.plotting
+    pymovements.reading_measures
+    pymovements.stimulus
     pymovements.synthetic
     pymovements.utils


### PR DESCRIPTION
## Description

Some modules where missing from the html documentation. This PR adds these.