### PR TITLE
hotfix: CopCo dataset precomputed events loading

### DIFF
--- a/src/pymovements/datasets/copco.py
+++ b/src/pymovements/datasets/copco.py
@@ -223,6 +223,7 @@ class CopCo(DatasetDefinition):
                 'infer_schema_length': 100000,
                 'truncate_ragged_lines': True,
                 'decimal_comma': True,
+                'quote_char': None,
             },
             'precomputed_reading_measures': {},
         },


### PR DESCRIPTION
there was a problem due to multi quotation marks 