### PR TITLE
fix: correctly add EyeTracker class to gaze module

### DIFF
--- a/src/pymovements/gaze/__init__.py
+++ b/src/pymovements/gaze/__init__.py
@@ -26,6 +26,7 @@
    :template: class.rst
 
     pymovements.gaze.Experiment
+    pymovements.gaze.EyeTracker
     pymovements.gaze.Screen
     pymovements.gaze.GazeDataFrame
 

--- a/src/pymovements/gaze/__init__.py
+++ b/src/pymovements/gaze/__init__.py
@@ -78,6 +78,7 @@
 from pymovements.gaze import transforms
 from pymovements.gaze import transforms_numpy
 from pymovements.gaze.experiment import Experiment
+from pymovements.gaze.eyetracker import EyeTracker
 from pymovements.gaze.gaze_dataframe import GazeDataFrame
 from pymovements.gaze.integration import from_numpy
 from pymovements.gaze.integration import from_pandas
@@ -89,6 +90,7 @@ from pymovements.gaze.screen import Screen
 
 __all__ = [
     'Experiment',
+    'EyeTracker',
     'from_numpy',
     'from_pandas',
     'GazeDataFrame',


### PR DESCRIPTION
## Description

The eye tracker class was missing from the docs
