### PR TITLE
feat: add center_offset parameter to pix2deg and center_origin

### DIFF
--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -20,10 +20,7 @@
 """Module for py:func:`pymovements.gaze.transforms."""
 from __future__ import annotations
 
-try:
-    from collections.abc import Callable  # noqa
-except ImportError:
-    from collections import Callable  # noqa
+from collections.abc import Callable
 from functools import partial
 from typing import Any
 from typing import TypeVar

--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -114,6 +114,7 @@ def center_origin(
         n_components: int,
         pixel_column: str = 'pixel',
         output_column: str | None = None,
+        center_offset: tuple[float, float] = (0, 0),
 ) -> pl.Expr:
     """Center pixel data.
 
@@ -131,6 +132,8 @@ def center_origin(
         Name of the input column with pixel data. (default: 'pixel')
     output_column: str | None
         Name of the output column with centered pixel data. (default: None)
+    center_offset: tuple[float, float]
+        Offset of the eye from the center in centimeters. (default: (0, 0))
 
     Returns
     -------
@@ -157,7 +160,8 @@ def center_origin(
 
     centered_pixels = pl.concat_list(
         [
-            pl.col(pixel_column).list.get(component) - origin_offset[component % 2]
+            pl.col(pixel_column).list.get(component) -
+            origin_offset[component % 2] - center_offset[component % 2]
             for component in range(n_components)
         ],
     ).alias(output_column)
@@ -224,6 +228,7 @@ def pix2deg(
         n_components: int,
         pixel_column: str = 'pixel',
         position_column: str = 'position',
+        center_offset: tuple[float, float] = (0, 0),
 ) -> pl.Expr:
     """Convert pixel screen coordinates to degrees of visual angle.
 
@@ -246,6 +251,8 @@ def pix2deg(
         The input pixel column name. (default: 'pixel')
     position_column: str
         The output position column name. (default: 'position')
+    center_offset: tuple[float, float]
+        Offset of the eye from the center in centimeters. (default: (0, 0))
 
     Returns
     -------
@@ -260,6 +267,7 @@ def pix2deg(
         origin=origin,
         n_components=n_components,
         pixel_column=pixel_column,
+        center_offset=center_offset,
     )
 
     if isinstance(distance, (float, int)):

--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -133,7 +133,8 @@ def center_origin(
     output_column: str | None
         Name of the output column with centered pixel data. (default: None)
     center_offset: tuple[float, float]
-        Offset of the eye from the center in centimeters. (default: (0, 0))
+        Offset of the eye from the center in centimeters.
+        A positive value moves the origin to the left or down. (default: (0, 0))
 
     Returns
     -------

--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -253,7 +253,8 @@ def pix2deg(
     position_column: str
         The output position column name. (default: 'position')
     center_offset: tuple[float, float]
-        Offset of the eye from the center in centimeters. (default: (0, 0))
+        Offset of the eye from the center in centimeters.
+        A positive value moves the origin to the left or down. (default: (0, 0))
 
     Returns
     -------

--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -20,7 +20,10 @@
 """Module for py:func:`pymovements.gaze.transforms."""
 from __future__ import annotations
 
-from collections.abc import Callable
+try:
+    from collections.abc import Callable  # noqa
+except ImportError:
+    from collections import Callable  # noqa
 from functools import partial
 from typing import Any
 from typing import TypeVar

--- a/tests/unit/gaze/gaze_transform_test.py
+++ b/tests/unit/gaze/gaze_transform_test.py
@@ -791,6 +791,82 @@ def fixture_experiment():
             id='clip',
         ),
 
+        pytest.param(
+            {
+                'data': pl.from_dict(
+                    {
+                        'time': [1000, 1000],
+                        'x_pix': [(100 - 1) / 2 + 10, (100 - 1) / 2 + 10],
+                        'y_pix': [10.0, 10.0],
+                        'distance': [1000, 1000],
+                    },
+                ),
+                'experiment': pm.Experiment(
+                    sampling_rate=1000,
+                    screen_width_px=100,
+                    screen_height_px=100,
+                    screen_width_cm=100,
+                    screen_height_cm=100,
+                    distance_cm=None,
+                    origin='center',
+                ),
+                'pixel_columns': ['x_pix', 'y_pix'],
+                'distance_column': 'distance',
+            },
+            'pix2deg', {'center_offset': (10, 10)},
+            pm.GazeDataFrame(
+                data=pl.from_dict(
+                    {
+                        'time': [1000, 1000],
+                        'x_pix': [59.5, 59.5],
+                        'y_pix': [10.0, 10.0],
+                        'x_dva': [26.3354, 26.3354],
+                        'y_dva': [0.0, 0.0],
+                        'distance': [1000, 1000],
+                    },
+                ),
+                pixel_columns=['x_pix', 'y_pix'],
+                position_columns=['x_dva', 'y_dva'],
+            ),
+            id='pix2deg_center_offset_center_origin',
+        ),
+
+        pytest.param(
+            {
+                'data': pl.from_dict(
+                    {
+                        'time': [1000],
+                        'x_pix': [(100 - 1) / 2 + 10],
+                        'y_pix': [10.0],
+                    },
+                ),
+                'experiment': pm.Experiment(
+                    sampling_rate=1000,
+                    screen_width_px=100,
+                    screen_height_px=100,
+                    screen_width_cm=100,
+                    screen_height_cm=100,
+                    distance_cm=100,
+                    origin='upper left',
+                ),
+                'pixel_columns': ['x_pix', 'y_pix'],
+            },
+            'pix2deg', {'center_offset': (10, 10)},
+            pm.GazeDataFrame(
+                data=pl.from_dict(
+                    {
+                        'time': [1000],
+                        'x_pix': [59.5],
+                        'y_pix': [10.0],
+                        'x_dva': [0.0],
+                        'y_dva': [-26.3354],
+                    },
+                ),
+                pixel_columns=['x_pix', 'y_pix'],
+                position_columns=['x_dva', 'y_dva'],
+            ),
+            id='pix2deg_center_offset_upper_left_origin',
+        ),
     ],
 )
 def test_gaze_transform_expected_frame(

--- a/tests/unit/gaze/transforms/center_origin_test.py
+++ b/tests/unit/gaze/transforms/center_origin_test.py
@@ -109,6 +109,24 @@ def test_center_origin_init_raises_error(kwargs, exception, msg_substrings):
             pl.Series('pixel', [[-49.5, 0]], pl.List(pl.Float64)),
             id='origin_lowerleft',
         ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100), 'origin': 'center', 'pixel_column': 'pixel',
+                'n_components': 2, 'center_offset': (10, 10),
+            },
+            pl.Series('pixel', [[0, (100 - 1) / 2]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[-10, 39.5]], pl.List(pl.Float64)),
+            id='origin_center_with_offset',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100), 'origin': 'upper left', 'pixel_column': 'pixel',
+                'n_components': 2, 'center_offset': (10, 10),
+            },
+            pl.Series('pixel', [[0, (100 - 1) / 2]], pl.List(pl.Float64)),
+            pl.Series('pixel', [[-59.5, -10]], pl.List(pl.Float64)),
+            id='origin_upper_left_with_offset',
+        ),
     ],
 )
 def test_center_origin_returns(kwargs, series, expected_df):

--- a/tests/unit/gaze/transforms/pix2deg_test.py
+++ b/tests/unit/gaze/transforms/pix2deg_test.py
@@ -499,6 +499,37 @@ def test_pix2deg_raises_error(kwargs, series, exception, msg_substrings):
             pl.Series('position', [[45, 63.4349]], pl.List(pl.Float64)),
             id='screen_size_different_values',
         ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 100,
+                'origin': 'center',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+                'center_offset': (10, 10),
+            },
+            pl.Series('pixel', [[10, 10]], pl.List(pl.Float64)),
+            pl.Series('position', [[0, 0]], pl.List(pl.Float64)),
+            id='center_offset_center_origin',
+        ),
+        pytest.param(
+            {
+                'screen_resolution': (100, 100),
+                'screen_size': (100, 100),
+                'distance': 50,
+                'origin': 'upper left',
+                'pixel_column': 'pixel',
+                'position_column': 'position',
+                'n_components': 2,
+                'center_offset': (10, 10),
+
+            },
+            pl.Series('pixel', [[0 + 10, 100 - 0.5 + 10]], pl.List(pl.Float64)),
+            pl.Series('position', [[-44.7120, 45]], pl.List(pl.Float64)),
+            id='isosceles_triangle_origin_lowerleft_returns_45_offset',
+        ),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Fixes #534 - Adding center_offset to center_origin function and propagating it to pix2deg.

## Implemented changes

The offset is implemented in the center_origin() function in pymovements.gaze.transforms.

The offset should be given in centimeters and is expected to be a tuple of floats with a zero default (center_offset: tuple[float, float] = (0, 0)). A positive value moves the origin to the left and down respectively.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

 - test offset in tests/unit/gaze/transforms/center_origin_test.py
 - test offset in tests/unit/gaze/transforms/pix2deg_test.py
 -  test offset in tests/unit/gaze/gaze_transform_test.py

In all cases two additional tests where created, one where the origin is top left and the other center. An offset of (10,10) is applied.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
