### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: tox --skip-pkg-install -e ${{ matrix.tox_env }}
       - name: Upload coverage reports to Codecov
         if: success() || failure()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Run test
         run: tox --skip-pkg-install -e docs
       - name: Upload documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-docs-${{ matrix.os }}
           path: docs/build/


### PR DESCRIPTION
Update dependencies on two GitHub actions

- codecov-action v4 -> v5
- upload-artifact v3 -> v4

> GitHub

>Artifact actions v3 will be closing down by January 30, 2025. You are receiving this email because you have GitHub Actions workflows using v3 of [actions/upload-artifact](https://app.github.media/e/er?s=88570519&lid=6648&elqTrackId=867ac6c9fa524bda9764f13bec8f8014&elq=bd6c906f63be4e008de0c641ac450301&elqaid=4286&elqat=1&elqak=8AF5D94B629B77D0B2E640E5D18BB16F179583EB7B3C6735E8C6767FA68D88AEC44B) or [actions/download-artifact](https://app.github.media/e/er?s=88570519&lid=6647&elqTrackId=bb54934dfd8c4c44b0e64ec2f2ba4824&elq=bd6c906f63be4e008de0c641ac450301&elqaid=4286&elqat=1&elqak=8AF57B355AADDDE608896B61A68B985ADA8483EB7B3C6735E8C6767FA68D88AEC44B). > After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.

> To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of actions/upload-artifact or actions/download-artifact. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

>    January 9th, 12pm - 1pm EST
>    January 16th, 10am-2pm EST
>    January 23rd, 9am-5pm EST

>What you need to do
>Update workflows to begin using v4 of the artifact actions as soon as possible. While v4 improves upload and download speeds by up to 98% and includes several new features, there are [key differences](https://app.github.media/e/er?s=88570519&lid=6646&elqTrackId=e5ab3eaa455c4e8baa6af6be9fdb5c62&elq=bd6c906f63be4e008de0c641ac450301&elqaid=4286&elqat=1&elqak=8AF58F0002C617A8A55C9135F66B9593810583EB7B3C6735E8C6767FA68D88AEC44B) from previous versions that may require updates to your workflows. Please see [the documentation](https://app.github.media/e/er?s=88570519&lid=6645&elqTrackId=af6fe6939f7e4dcba105e35734b7e6a0&elq=bd6c906f63be4e008de0c641ac450301&elqaid=4286&elqat=1&elqak=8AF5780CABD5F82033875E5CE3EF4DF2FDFC83EB7B3C6735E8C6767FA68D88AEC44B) in the project repositories for guidance on how to migrate your workflows.
