### PR TITLE
feat: Improve regex parsing for DISPLAY_COORDS in asc meta data

### DIFF
--- a/src/pymovements/utils/parsing.py
+++ b/src/pymovements/utils/parsing.py
@@ -47,7 +47,7 @@ EYELINK_META_REGEXES = [
             r'\s+(?P<day>\d\d?)\s+(?P<time>\d\d:\d\d:\d\d)\s+(?P<year>\d{4})\s*'
         ),
         r'\*\*\s+(?P<version_2>EYELINK.*)',
-        r'MSG\s+\d+[.]?\d*\s+DISPLAY_COORDS\s+(?P<resolution>.*)',
+        r'MSG\s+\d+[.]?\d*\s+DISPLAY_COORDS\s*=?\s*(?P<resolution>.*)',
         (
             r'MSG\s+\d+[.]?\d*\s+RECCFG\s+(?P<tracking_mode>[A-Z,a-z]+)\s+'
             r'(?P<sampling_rate>\d+)\s+'


### PR DESCRIPTION
## Description

asc files with an = sign after DISPLAY_COORDS couldn't be parsed. Origin of said asc file is EyeLinkViewer, where the pdf was converted to asc.
bug causing example line: 
`MSG	1946201 DISPLAY_COORDS = 0 0 1919 1079`

Fixes #

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] Updated regex pattern for DISPLAY_COORDS to allow an optional = character before the resolution value
```
-        r'MSG\s+\d+[.]?\d*\s+DISPLAY_COORDS\s+(?P<resolution>.*)',
+        r'MSG\s+\d+[.]?\d*\s+DISPLAY_COORDS\s*=?\s*(?P<resolution>.*)',
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Tested with an asc file with the line 
`MSG	1946201 DISPLAY_COORDS = 0 0 1919 1079`
- [x] Tested with the example file eyelink_monocular_2khz_example.asc 
`MSG	2095865.0 DISPLAY_COORDS 0 0 1279 1023`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
