### PR TITLE
hotfix: make timestamp in msg_prefix for metadata regex compile optional

### DIFF
--- a/src/pymovements/utils/parsing.py
+++ b/src/pymovements/utils/parsing.py
@@ -128,7 +128,7 @@ def compile_patterns(patterns: list[dict[str, Any] | str]) -> list[dict[str, Any
     list[dict[str, Any]]
         Returns from string compiled regex patterns.
     """
-    msg_prefix = r'MSG\s+\d+[.]?\d*\s+'
+    msg_prefix = r'MSG\s+(?:\d+?[.]?\d*\s+)?'
 
     compiled_patterns = []
 


### PR DESCRIPTION
as raised in #939 some people might want to extract the timestamp of a custom metadata type. I currently don't know if this would be possible. this PR provides a patch which fixes the problem raised in #939 while maintaining all other properties of `compile_patterns`.


I've additionally added a test which reproduces the problem. the code change of interest is in `src/pymovements/utils/parsing.py`.


feel free to reject this proposed change with a strategy to pass the new test (`test_extract_timestamp_for_metadata`) in `tests/unit/gaze/io/asc_test.py` and comment the solution on #939. additionally, we should double check documentation s.t. people can easily extract custom (meta)data from ascii files.

resolves #939 