### PR TITLE
ci: use minor versions as upper bound in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
   "pytest>=6.0.0",
   "pytest-cov>=4.0.0",
   "setuptools>=61.0.0",
-  "types-tqdm>=4.64.0,<5",
+  "types-tqdm>=4.64.0,<5"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,14 @@ classifiers = [
 ]
 dependencies = [
   "matplotlib>=3.8.0,<3.11",
-  "numpy>=1.22.4,<3",
-  "pandas>=2.1.4,<3",
-  "polars>=1.21.0,<2",
-  "pyarrow>=11.0.0,<20",
-  "pyopenssl>=16.0.0,<26.0.0",
-  "scipy>=1.8.0,<2",
-  "tqdm>=4.27.0,<5",
-  "typing_extensions>=4.0.0,<5"
+  "numpy>=1.22.4,<2.3",
+  "pandas>=2.1.4,<2.3",
+  "polars>=1.21.0,<1.23",
+  "pyarrow>=11.0.0,<19.1",
+  "pyopenssl>=16.0.0,<25.1",
+  "scipy>=1.8.0,<1.16",
+  "tqdm>=4.27.0,<4.68",
+  "typing_extensions>=4.0.0,<4.13"
 ]
 dynamic = ["version"]
 
@@ -68,7 +68,6 @@ test = [
   "pytest-cov>=4.0.0",
   "setuptools>=61.0.0",
   "types-tqdm>=4.64.0,<5",
-  "typing_extensions>=4.0.0,<5"
 ]
 
 [project.urls]


### PR DESCRIPTION
the issue with #935 could happen because dependabot didn't check for minor version updates.

according to semantic versioning, deprecations can be introduced in minor version updates. there are basically two ways how we can treat deprecation warnings in CI:
- treat warnings as errors
- print warnings

We decided to treat warnings as errors some time ago and I still think that it's the most sensible approach, as I rarely read the warnings in CI tests. 

The problem is, that we specified major versions as upper bounds in `pyproject.toml`. dependabot would therefore only try to update the dependencies if a major version update happens. that's why the CI suddenly failed in unrelated new PRs, as a deprecation was introduced to polars.

In this PR I changed the upper bounds of the dependencies to minor versions. This means that we will get more dependabot spam again, but we're getting warned in time about deprecations in the dependabot PR, and unrelated PRs won't get any issues with deprecations.

If dependabot reveals some new deprecations, we can still decide in the dependabotPR if we want to apply the required changes in code or ignore the specific deprecation warning and create an issue.

Overall, I would say that it's really important that recent deprecations in dependencies do not mess with any development in unrelated PRs, so something like what happened to @saeub shouldn't happen again.

This PR should solve the issue.
