### PR TITLE
ci: use correct documentation label in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,7 +24,7 @@ categories:
       - build
       - internal
   - title: 🔖 Documentation
-    labels: docs
+    labels: documentation
 
 exclude-labels:
   - skip changelog


### PR DESCRIPTION
I made an error in #988 

the autolabel uses the label `documentation`, all our issues&prs use this label as well.

