### PR TITLE
feat: Parse SMI BeGaze raw data files

### DIFF
--- a/tests/unit/gaze/_utils/_parsing_test.py
+++ b/tests/unit/gaze/_utils/_parsing_test.py
@@ -104,6 +104,77 @@ EBLINK R 10000018	10000020	2
 END	10000022 	SAMPLES	EVENTS	RES	  38.54	  31.12
 """
 
+BEGAZE_TEXT = r"""
+## [BeGaze]
+## Converted from:	C:\test.idf
+## Date:	08.03.2023 09:25:20
+## Version:	BeGaze 3.7.40
+## IDF Version:	9
+## Sample Rate:	1000
+## Separator Type:	Msg
+## Trial Count:	1
+## Uses Plane File:	False
+## Number of Samples:	11
+## Reversed:	none
+## [Run]
+## Subject:	P01
+## Description:	Run1
+## [Calibration]
+## Calibration Area:	1680	1050
+## Calibration Point 0:	Position(841;526)
+## Calibration Point 1:	Position(84;52)
+## Calibration Point 2:	Position(1599;52)
+## Calibration Point 3:	Position(84;1000)
+## Calibration Point 4:	Position(1599;1000)
+## Calibration Point 5:	Position(84;526)
+## Calibration Point 6:	Position(841;52)
+## Calibration Point 7:	Position(1599;526)
+## Calibration Point 8:	Position(841;1000)
+## [Geometry]
+## Stimulus Dimension [mm]:	474	297
+## Head Distance [mm]:	700
+## [Hardware Setup]
+## System ID:	IRX0470703-1007
+## Operating System :	6.1
+## IView X Version:	2.8.26
+## [Filter Settings]
+## Heuristics:	False
+## Heuristics Stage:	0
+## Bilateral:	True
+## Gaze Cursor Filter:	True
+## Saccade Length [px]:	80
+## Filter Depth [ms]:	20
+## Format:	LEFT, POR, QUALITY, PLANE, MSG
+##
+Time	Type	Trial	L POR X [px]	L POR Y [px]	L Pupil Diameter [mm]	Timing	Pupil Confidence	R Plane	Info	R Event Info	Stimulus
+10000000123	SMP	1	850.71	717.53	714.00	0	1	1	1	-	test.bmp
+10000000234	MSG	1	# Message: START_A
+10000002123	SMP	1	850.71	717.53	714.00	0	1	1	1	-	test.bmp
+10000003234	MSG	1	# Message: STOP_A
+10000004123	SMP	1	850.71	717.53	714.00	0	1	1	1	-	test.bmp
+10000004234	MSG	1	# Message: METADATA_1 123
+10000005234	MSG	1	# Message: START_B
+10000006123	SMP	1	850.71	717.53	714.00	0	1	1	1	-	test.bmp
+10000007234	MSG	1	# Message: START_TRIAL_1
+10000008123	SMP	1	850.71	717.53	714.00	0	1	1	1	-	test.bmp
+10000009234	MSG	1	# Message: STOP_TRIAL_1
+10000010234	MSG	1	# Message: START_TRIAL_2
+10000011123	SMP	1	850.71	717.53	714.00	0	1	1	1	-	test.bmp
+10000012234	MSG	1	# Message: STOP_TRIAL_2
+10000013234	MSG	1	# Message: START_TRIAL_3
+10000014234	MSG	1	# Message: METADATA_2 abc
+10000014235	MSG	1	# Message: METADATA_1 456
+10000014345	SMP	1	850.71	717.53	714.00	0	1	1	1	-	test.bmp
+10000015234	MSG	1	# Message: STOP_TRIAL_3
+10000016234	MSG	1	# Message: STOP_B
+10000017234	MSG	1	# Message: METADATA_3
+10000017345	SMP	1	850.71	717.53	714.00	0	0	-1	-1	-	test.bmp
+10000019123	SMP	1	850.71	717.53	714.00	0	0	-1	-1	Blink	test.bmp
+10000020123	SMP	1	850.71	717.53	714.00	0	0	-1	-1	Blink	test.bmp
+10000021123	SMP	1	850.71	717.53	714.00	0	0	1	-1	-	test.bmp
+"""  # noqa: E501
+
+
 PATTERNS = [
     {
         'pattern': 'START_A',
@@ -150,7 +221,7 @@ EXPECTED_DF = pl.from_dict(
     },
 )
 
-EXPECTED_METADATA = {
+EXPECTED_METADATA_EYELINK = {
     'weekday': 'Wed',
     'month': 'Mar',
     'day': 8,
@@ -191,6 +262,26 @@ EXPECTED_METADATA = {
     'metadata_4': None,
 }
 
+# TODO: Add more metadata
+EXPECTED_METADATA_BEGAZE = {
+    'sampling_rate': 1000.00,
+    'tracked_eye': 'L',
+    'data_loss_ratio_blinks': 0.18181818181818182,
+    'data_loss_ratio': 0.2727272727272727,
+    'total_recording_duration_ms': 11,
+    'datetime': datetime.datetime(2023, 3, 8, 9, 25, 20),
+    'blinks': [{
+        'duration_ms': 2,
+        'num_samples': 2,
+        'start_timestamp': 10000019.123,
+        'stop_timestamp': 10000021.123,
+    }],
+    'metadata_1': '123',
+    'metadata_2': 'abc',
+    'metadata_3': True,
+    'metadata_4': None,
+}
+
 
 def test_parse_eyelink(tmp_path):
     filepath = tmp_path / 'sub.asc'
@@ -203,7 +294,7 @@ def test_parse_eyelink(tmp_path):
     )
 
     assert_frame_equal(df, EXPECTED_DF, check_column_order=False)
-    assert metadata == EXPECTED_METADATA
+    assert metadata == EXPECTED_METADATA_EYELINK
 
 
 @pytest.mark.parametrize(
@@ -918,3 +1009,17 @@ def test_parse_eyelink_encoding(tmp_path, bytestring, encoding, expected_text):
     )
 
     assert parsed_metadata['text'] == expected_text
+
+
+def test_parse_begaze(tmp_path):
+    filepath = tmp_path / 'sub.txt'
+    filepath.write_text(BEGAZE_TEXT)
+
+    df, metadata = pm.gaze._utils.parsing.parse_begaze(
+        filepath,
+        patterns=PATTERNS,
+        metadata_patterns=METADATA_PATTERNS,
+    )
+
+    assert_frame_equal(df, EXPECTED_DF, check_column_order=False)
+    assert metadata == EXPECTED_METADATA_BEGAZE


### PR DESCRIPTION
## Description

Read BeGaze text files. Not aiming for full support for now (I don't have enough data for testing), but at least the raw samples and events in DIDEC should be parsed successfully (#980).

#945 should be merged first (so that events can be implemented and tested the same way as for EyeLink)

Fixes #981

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [ ] Implement `parse_begaze()` like `parse_eyelink()`
- [ ] Implement `from_begaze()` like `from_asc()`
- [ ] :question: Figure out a way to route BeGaze files through `from_begaze()` when loading datasets, even if the file extension is `.txt` (currently they are routed through `from_csv()`, not sure if this behavior is required by other datasets)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] `test_parse_begaze()`
- [ ] Update `test_parse_begaze()` after #945 is merged
- [ ] DIDEC tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
