### PR TITLE
fix: return DatasetDefinition copy by DatasetLibrary.get()

### DIFF
--- a/src/pymovements/dataset/dataset_library.py
+++ b/src/pymovements/dataset/dataset_library.py
@@ -63,6 +63,17 @@ class DatasetLibrary:
         """
         return cls.definitions[name]
 
+    @classmethod
+    def list(cls) -> list[str]:
+        """Get list of names of all added datasets in library.
+
+        Returns
+        -------
+        list[str]
+            List of dataset names that are included in the dataset library.
+        """
+        return list(cls.definitions.keys())
+
 
 DatsetDefinitionClass = TypeVar('DatsetDefinitionClass', bound=type[DatasetDefinition])
 

--- a/src/pymovements/dataset/dataset_library.py
+++ b/src/pymovements/dataset/dataset_library.py
@@ -20,6 +20,7 @@
 """DatasetLibrary module."""
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TypeVar
 
 from pymovements.dataset.dataset_definition import DatasetDefinition
@@ -49,7 +50,7 @@ class DatasetLibrary:
 
     @classmethod
     def get(cls, name: str) -> type[DatasetDefinition]:
-        """Get :py:class:`~pymovements.dataset.DatasetDefinition` py name.
+        """Get copy of :py:class:`~pymovements.dataset.DatasetDefinition` py name.
 
         Parameters
         ----------
@@ -61,7 +62,7 @@ class DatasetLibrary:
         type[DatasetDefinition]
             The :py:class:`~pymovements.dataset.DatasetDefinition` in the library.
         """
-        return cls.definitions[name]
+        return deepcopy(cls.definitions[name])
 
     @classmethod
     def list(cls) -> list[str]:

--- a/src/pymovements/gaze/experiment.py
+++ b/src/pymovements/gaze/experiment.py
@@ -200,8 +200,6 @@ class Experiment:
 
     def __eq__(self: Experiment, other: Experiment) -> bool:
         """Compare equality to other Experiment."""
-        print(self.screen, other.screen, self.screen == other.screen)
-        print(self.eyetracker, other.eyetracker, self.eyetracker == other.eyetracker)
         return self.screen == other.screen and self.eyetracker == other.eyetracker
 
     def __str__(self: Experiment) -> str:

--- a/tests/unit/dataset/dataset_definition_test.py
+++ b/tests/unit/dataset/dataset_definition_test.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+from pymovements import DatasetDefinition
+from pymovements import Experiment
+
+
+@pytest.mark.parametrize(
+    'init_kwargs',
+    [
+        pytest.param(
+            {'name': 'A'},
+            id='name_only',
+        ),
+        pytest.param(
+            {'name': 'A', 'experiment': Experiment(sampling_rate=1000)},
+            id='name_and_experiment',
+        ),
+    ],
+)
+def test_dataset_definition_is_equal(init_kwargs):
+    definition1 = DatasetDefinition(**init_kwargs)
+    definition2 = DatasetDefinition(**init_kwargs)
+
+    assert definition1 == definition2

--- a/tests/unit/dataset/dataset_library_test.py
+++ b/tests/unit/dataset/dataset_library_test.py
@@ -21,7 +21,7 @@
 import pymovements as pm
 
 
-def test_add_single_defintion():
+def test_add_single_definition():
     class CustomDatasetDefinition(pm.DatasetDefinition):
         name: str = 'CustomDatasetDefinition'
 
@@ -31,7 +31,7 @@ def test_add_single_defintion():
     assert definition == CustomDatasetDefinition
 
 
-def test_add_two_defintions():
+def test_add_two_definitions():
     class CustomDatasetDefinition1(pm.DatasetDefinition):
         name: str = 'CustomDatasetDefinition1'
 
@@ -59,3 +59,12 @@ def test_list_names_is_list_of_str():
 
     for name in names:
         assert isinstance(name, str)
+
+
+def test_returned_definition_is_copy():
+    name = list(pm.DatasetLibrary.definitions.keys())[0]
+
+    internal_definition = pm.DatasetLibrary.definitions[name]
+    output_definition = pm.DatasetLibrary.get(name)
+
+    assert internal_definition is not output_definition

--- a/tests/unit/dataset/dataset_library_test.py
+++ b/tests/unit/dataset/dataset_library_test.py
@@ -46,3 +46,16 @@ def test_add_two_defintions():
 
     assert definition1 == CustomDatasetDefinition1
     assert definition2 == CustomDatasetDefinition2
+
+
+def test_library_not_empty():
+    assert len(pm.DatasetLibrary.definitions) >= 0
+
+
+def test_list_names_is_list_of_str():
+    names = pm.DatasetLibrary.list()
+
+    assert isinstance(names, list)
+
+    for name in names:
+        assert isinstance(name, str)


### PR DESCRIPTION
## Description

#914 exposed a bug in `resample()`: the experiment of the dataset definition is not just updated in the `GazeDataFrame` itself, but also in the `DatasetLibrary`. This really shouldn't happen.


## Implemented changes

Insert a description of the changes implemented in the pull request.

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is or requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
