### PR TITLE
ci: change documentation emoji in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,7 +23,7 @@ categories:
     labels:
       - build
       - internal
-  - title: 🔖 Documentation
+  - title: 📖 Documentation
     labels: documentation
 
 exclude-labels:


### PR DESCRIPTION
The bookmark emoji 🔖 doesn't look right.

I changed it to the open book emoji 📖

