### PR TITLE
chore: Create issue template for adding new datasets

### DIFF
--- a/.github/ISSUE_TEMPLATE/DATASET.md
+++ b/.github/ISSUE_TEMPLATE/DATASET.md
@@ -1,0 +1,17 @@
+---
+name: New Dataset
+about: Use this template to add or announce a new dataset
+title: "[DATASET NAME]"
+labels: dataset
+assignees:
+---
+
+
+## Dataset Description
+Provide a description on the dataset.
+
+## Dataset Citation
+Provide a citation to the dataset, ideally in bibtex format.
+
+## Dataset Resources
+Provide URLs to all dataset resources and specify their content.


### PR DESCRIPTION
This enables providing a URL to contributors for creating issues related to their dataset, that adhere to a specific template.

Also, when you click on "New Issue" you will be able to select "New Dataset" next to "Feature Request" or "Issue Report"

issues are automatically labeled as `dataset`.

The template can probably extended with additional sections, so suggestions are welcome!