### PR TITLE
fix: deduplicate resource filenames in UCL dataset

### DIFF
--- a/src/pymovements/datasets/ucl.py
+++ b/src/pymovements/datasets/ucl.py
@@ -122,14 +122,14 @@ class UCL(DatasetDefinition):
             'precomputed_events': [
                 {
                     'resource': '13428_2012_313_MOESM1_ESM.zip',
-                    'filename': 'UCL.zip',
+                    'filename': 'UCL_events.zip',
                     'md5': '77e3c0cacccb0a074a55d23aa8531ca5',
                 },
             ],
             'precomputed_reading_measures': [
                 {
                     'resource': '13428_2012_313_MOESM1_ESM.zip',
-                    'filename': 'UCL.zip',
+                    'filename': 'UCL_measures.zip',
                     'md5': '77e3c0cacccb0a074a55d23aa8531ca5',
                 },
             ],

--- a/src/pymovements/datasets/ucl.yaml
+++ b/src/pymovements/datasets/ucl.yaml
@@ -14,11 +14,11 @@ mirrors:
 resources:
   precomputed_events:
     - resource: "13428_2012_313_MOESM1_ESM.zip"
-      filename: "UCL.zip"
+      filename: "UCL_events.zip"
       md5: "77e3c0cacccb0a074a55d23aa8531ca5"
   precomputed_reading_measures:
     - resource: "13428_2012_313_MOESM1_ESM.zip"
-      filename: "UCL.zip"
+      filename: "UCL_measures.zip"
       md5: "77e3c0cacccb0a074a55d23aa8531ca5"
 
 extract:


### PR DESCRIPTION
The UCL dataset fails the tests in #1049 if `remove_finished=True`.

Reason: resource filename is duplicated, hence archive is already removed before being extracted (again).

This is just a workaround before fixing the underlying issue of handling filename duplicates in resources.

Here's one of the failed jobs: https://github.com/aeye-lab/pymovements/actions/runs/13903514974/job/38903529945?pr=1049