### PR TITLE
Dataset info

### DIFF
--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -1058,6 +1058,14 @@ class Dataset:
         return self
 
     @property
+    def info(self) -> None:
+        """The information about the dataset.
+
+        Print dataset information and citation key.
+        """
+        print(self.definition.info)
+
+    @property
     def path(self) -> Path:
         """The path to the dataset directory.
 

--- a/src/pymovements/dataset/dataset_definition.py
+++ b/src/pymovements/dataset/dataset_definition.py
@@ -47,6 +47,9 @@ class DatasetDefinition:
     ----------
     name: str
         The name of the dataset. (default: '.')
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information. (default: '.')
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -142,6 +145,9 @@ class DatasetDefinition:
 
     # pylint: disable=too-many-instance-attributes
     name: str = '.'
+
+    info: str = ''
+
     has_files: dict[str, bool] = field(default_factory=dict)
 
     mirrors: dict[str, list[str]] | dict[str, tuple[str, ...]] = field(default_factory=dict)

--- a/src/pymovements/datasets/bsc.py
+++ b/src/pymovements/datasets/bsc.py
@@ -44,6 +44,10 @@ class BSC(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -103,6 +107,30 @@ class BSC(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'BSC'
+
+    info: str = """\
+BSC dataset :cite:p:`BSC`.
+
+This dataset includes monocular eye tracking data from several participants in a single
+session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+eye tracker and precomputed events on aoi level are reported.
+
+The participant is instructed to read texts and answer questions.
+
+Check the respective paper for details :cite:p:`BSC`.
+
+If you use the dataset, please cite:
+
+@article{BSC,
+    author={Pan, Jinger and Yan, Ming and Richter, Eike M. and Shu, Hua and Kliegl, Reinhold},
+    title={The {B}eijing {S}entence {C}orpus: A {C}hinese sentence corpus
+    with eye movement data and predictability norms},
+    journal={Behavior Research Methods},
+    year={2022},
+    volume={54},
+    issue={4},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/bsc.py
+++ b/src/pymovements/datasets/bsc.py
@@ -31,7 +31,7 @@ from pymovements.dataset.dataset_definition import DatasetDefinition
 class BSC(DatasetDefinition):
     """BSC dataset :cite:p:`BSC`.
 
-    This dataset includes monocular eye tracking data from a single participant in a single
+    This dataset includes monocular eye tracking data from several participants in a single
     session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
     eye tracker and precomputed events on aoi level are reported.
 
@@ -88,11 +88,11 @@ class BSC(DatasetDefinition):
     Examples
     --------
     Initialize your :py:class:`~pymovements.dataset.Dataset` object with the
-    :py:class:`~pymovements.datasets.SBSAT` definition:
+    :py:class:`~pymovements.datasets.BSC` definition:
 
     >>> import pymovements as pm
     >>>
-    >>> dataset = pm.Dataset("SBSAT", path='data/SBSAT')
+    >>> dataset = pm.Dataset("BSC", path='data/BSC')
 
     Download the dataset resources:
 

--- a/src/pymovements/datasets/bsc.yaml
+++ b/src/pymovements/datasets/bsc.yaml
@@ -1,5 +1,28 @@
 name: BSC
 
+info: |
+    BSC dataset :cite:p:`BSC`.
+
+    This dataset includes monocular eye tracking data from several participants in a single
+    session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+    eye tracker and precomputed events on aoi level are reported.
+
+    The participant is instructed to read texts and answer questions.
+
+    Check the respective paper for details :cite:p:`BSC`.
+
+    If you use the dataset, please cite:
+
+    @article{BSC,
+        author={Pan, Jinger and Yan, Ming and Richter, Eike M. and Shu, Hua and Kliegl, Reinhold},
+        title={The {B}eijing {S}entence {C}orpus: A {C}hinese sentence corpus
+        with eye movement data and predictability norms},
+        journal={Behavior Research Methods},
+        year={2022},
+        volume={54},
+        issue={4},
+    }
+
 has_files:
   gaze: false
   precomputed_events: true

--- a/src/pymovements/datasets/bsc2.py
+++ b/src/pymovements/datasets/bsc2.py
@@ -31,7 +31,7 @@ from pymovements.dataset.dataset_definition import DatasetDefinition
 class BSCII(DatasetDefinition):
     """BSCII dataset :cite:p:`BSCII`.
 
-    This dataset includes monocular eye tracking data from a single participant in a single
+    This dataset includes monocular eye tracking data from several participants in a single
     session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
     eye tracker and precomputed events on aoi level are reported.
 
@@ -112,7 +112,7 @@ class BSCII(DatasetDefinition):
     info: str = """\
 BSCII dataset :cite:p:`BSCII`.
 
-This dataset includes monocular eye tracking data from a single participant in a single
+This dataset includes monocular eye tracking data from several participants in a single
 session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
 eye tracker and precomputed events on aoi level are reported.
 

--- a/src/pymovements/datasets/bsc2.py
+++ b/src/pymovements/datasets/bsc2.py
@@ -45,6 +45,10 @@ class BSCII(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -104,6 +108,31 @@ class BSCII(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'BSCII'
+
+    info: str = """\
+BSCII dataset :cite:p:`BSCII`.
+
+This dataset includes monocular eye tracking data from a single participant in a single
+session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+eye tracker and precomputed events on aoi level are reported.
+
+The participant is instructed to read texts and answer questions. The original purpose was to
+look into the differences in processing when reading simplified and traditional Chinese.
+
+Check the respective paper for details :cite:p:`BSCII`.
+
+If you use the dataset, please cite:
+
+@article{BSCII,
+    author={Yan, Ming and Pan, Jinger and Kliegl, Reinhold},
+    title={The {B}eijing {S}entence {C}orpus {II}: A cross-script comparison
+    between traditional and simplified Chinese sentence reading},
+    journal={Behavior Research Methods},
+    year={2025},
+    volume={57},
+    issue={2},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/bsc2.yaml
+++ b/src/pymovements/datasets/bsc2.yaml
@@ -3,7 +3,7 @@ name: "BSCII"
 info: |
     BSCII dataset :cite:p:`BSCII`.
 
-    This dataset includes monocular eye tracking data from a single participant in a single
+    This dataset includes monocular eye tracking data from several participants in a single
     session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
     eye tracker and precomputed events on aoi level are reported.
 

--- a/src/pymovements/datasets/bsc2.yaml
+++ b/src/pymovements/datasets/bsc2.yaml
@@ -1,5 +1,29 @@
 name: "BSCII"
 
+info: |
+    BSCII dataset :cite:p:`BSCII`.
+
+    This dataset includes monocular eye tracking data from a single participant in a single
+    session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+    eye tracker and precomputed events on aoi level are reported.
+
+    The participant is instructed to read texts and answer questions. The original purpose was to
+    look into the differences in processing when reading simplified and traditional Chinese.
+
+    Check the respective paper for details :cite:p:`BSCII`.
+
+    If you use the dataset, please cite:
+
+    @article{BSCII,
+        author={Yan, Ming and Pan, Jinger and Kliegl, Reinhold},
+        title={The {B}eijing {S}entence {C}orpus {II}: A cross-script comparison
+        between traditional and simplified Chinese sentence reading},
+        journal={Behavior Research Methods},
+        year={2025},
+        volume={57},
+        issue={2},
+    }
+
 has_files:
   gaze: false
   precomputed_events: true

--- a/src/pymovements/datasets/codecomprehension.py
+++ b/src/pymovements/datasets/codecomprehension.py
@@ -44,6 +44,10 @@ class CodeComprehension(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -97,6 +101,36 @@ class CodeComprehension(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'CodeComprehension'
+
+    info: str = """\
+CodeComprehension dataset :cite:p:`CodeComprehension`.
+
+This dataset includes eye-tracking-while-code-reading data from participants in a single
+session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an
+EyeLink 1000 eye tracker and are provided as pixel coordinates.
+
+The participant is instructed to read the code snippet and answer a code comprehension question.
+
+If you use the dataset, please cite:
+
+@article{CodeComprehension,
+  author = {Alakmeh, Tarek and Reich, David and J\\"{a}ger, Lena and Fritz, Thomas},
+  title = {Predicting Code Comprehension: A Novel Approach to
+  Align Human Gaze with Code using Deep Neural Networks},
+  year = {2024},
+  issue_date = {July 2024},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  volume = {1},
+  number = {FSE},
+  url = {https://doi.org/10.1145/3660795},
+  doi = {10.1145/3660795},
+  journal = {Proc. ACM Softw. Eng.},
+  month = {jul},
+  articleno = {88},
+  numpages = {23},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/codecomprehension.yaml
+++ b/src/pymovements/datasets/codecomprehension.yaml
@@ -1,5 +1,34 @@
 name: CodeComprehension
 
+info: |
+    CodeComprehension dataset :cite:p:`CodeComprehension`.
+
+    This dataset includes eye-tracking-while-code-reading data from participants in a single
+    session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an
+    EyeLink 1000 eye tracker and are provided as pixel coordinates.
+
+    The participant is instructed to read the code snippet and answer a code comprehension question.
+
+    If you use the dataset, please cite:
+
+    @article{CodeComprehension,
+      author = {Alakmeh, Tarek and Reich, David and J\"{a}ger, Lena and Fritz, Thomas},
+      title = {Predicting Code Comprehension: A Novel Approach to
+      Align Human Gaze with Code using Deep Neural Networks},
+      year = {2024},
+      issue_date = {July 2024},
+      publisher = {Association for Computing Machinery},
+      address = {New York, NY, USA},
+      volume = {1},
+      number = {FSE},
+      url = {https://doi.org/10.1145/3660795},
+      doi = {10.1145/3660795},
+      journal = {Proc. ACM Softw. Eng.},
+      month = {jul},
+      articleno = {88},
+      numpages = {23},
+    }
+
 has_files:
   gaze: false
   precomputed_events: true

--- a/src/pymovements/datasets/copco.py
+++ b/src/pymovements/datasets/copco.py
@@ -32,7 +32,7 @@ from pymovements.gaze.experiment import Experiment
 class CopCo(DatasetDefinition):
     """CopCo dataset :cite:p:`CopCoL1Hollenstein`.
 
-    This dataset includes monocular eye tracking data from a single participants in a single
+    This dataset includes monocular eye tracking data from 58 participants in a single
     session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
     eye tracker and are provided as pixel coordinates.
 
@@ -133,7 +133,7 @@ class CopCo(DatasetDefinition):
     info: str = """\
 CopCo dataset :cite:p:`CopCoL1Hollenstein`.
 
-This dataset includes monocular eye tracking data from a single participants in a single
+This dataset includes monocular eye tracking data from 58 participants in a single
 session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
 eye tracker and are provided as pixel coordinates.
 

--- a/src/pymovements/datasets/copco.py
+++ b/src/pymovements/datasets/copco.py
@@ -48,6 +48,10 @@ class CopCo(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -125,6 +129,93 @@ class CopCo(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'CopCo'
+
+    info: str = """\
+CopCo dataset :cite:p:`CopCoL1Hollenstein`.
+
+This dataset includes monocular eye tracking data from a single participants in a single
+session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+eye tracker and are provided as pixel coordinates.
+
+The participant is instructed to read texts and answer questions.
+
+The dataset includes the data from three papers:
+    the L1 data: :cite:p:`CopCoL1Hollenstein`,
+    the L1 data with dylsexia: :cite:p:`CopCoL1DysBjornsdottir`,
+    the L2 data: :cite:p:`CopCoL2`,
+
+If you use the dataset, please cite:
+  For L1:
+    @inproceedings{CopCoL1Hollenstein,
+      title = "The {C}openhagen Corpus of Eye Tracking Recordings from
+      Natural Reading of {D}anish Texts",
+      author = {Hollenstein, Nora  and
+        Barrett, Maria  and
+        Bj{\\"o}rnsd{\\'o}ttir, Marina},
+      editor = "Calzolari, Nicoletta  and
+        B{\\'e}chet, Fr{\\'e}d{\\'e}ric  and
+        Blache, Philippe  and
+        Choukri, Khalid  and
+        Cieri, Christopher  and
+        Declerck, Thierry  and
+        Goggi, Sara  and
+        Isahara, Hitoshi  and
+        Maegaard, Bente  and
+        Mariani, Joseph  and
+        Mazo, H{\\'e}l{\\`e}ne  and
+        Odijk, Jan  and
+        Piperidis, Stelios",
+      booktitle = "Proceedings of the Thirteenth Language Resources and Evaluation Conference",
+      month = jun,
+      year = "2022",
+      address = "Marseille, France",
+      publisher = "European Language Resources Association",
+      url = "https://aclanthology.org/2022.lrec-1.182",
+      pages = "1712--1720",
+    }
+
+  For L1 with dyslexia:
+    @inproceedings{CopCoL1DysBjornsdottir,
+      title = "Dyslexia Prediction from Natural Reading of {D}anish Texts",
+      author = {Bj{\\"o}rnsd{\\'o}ttir, Marina  and
+        Hollenstein, Nora  and
+        Barrett, Maria},
+      editor = {Alum{\\"a}e, Tanel  and
+        Fishel, Mark},
+      booktitle = "Proceedings of the 24th Nordic Conference on
+      Computational Linguistics (NoDaLiDa)",
+      month = may,
+      year = "2023",
+      address = "T{\\'o}rshavn, Faroe Islands",
+      publisher = "University of Tartu Library",
+      url = "https://aclanthology.org/2023.nodalida-1.7",
+      pages = "60--70",
+    }
+  For L2:
+    @inproceedings{CopCoL2,
+      title = "Reading Does Not Equal Reading:
+      Comparing, Simulating and Exploiting Reading Behavior across Populations",
+      author = {Reich, David R.  and
+        Deng, Shuwen  and
+        Bj{\\"o}rnsd{\\'o}ttir, Marina  and
+        J{\\"a}ger, Lena  and
+        Hollenstein, Nora},
+      editor = "Calzolari, Nicoletta  and
+        Kan, Min-Yen  and
+        Hoste, Veronique  and
+        Lenci, Alessandro  and
+        Sakti, Sakriani  and
+        Xue, Nianwen",
+      booktitle = "Proceedings of the 2024 Joint International Conference on
+      Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024)",
+      month = may,
+      year = "2024",
+      address = "Torino, Italia",
+      publisher = "ELRA and ICCL",
+      url = "https://aclanthology.org/2024.lrec-main.1187",
+      pages = "13586--13594",
+    }
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/copco.yaml
+++ b/src/pymovements/datasets/copco.yaml
@@ -3,7 +3,7 @@ name: "CopCo"
 info: |
     CopCo dataset :cite:p:`CopCoL1Hollenstein`.
 
-    This dataset includes monocular eye tracking data from a single participants in a single
+    This dataset includes monocular eye tracking data from 58 participants in a single
     session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
     eye tracker and are provided as pixel coordinates.
 

--- a/src/pymovements/datasets/copco.yaml
+++ b/src/pymovements/datasets/copco.yaml
@@ -1,5 +1,91 @@
 name: "CopCo"
 
+info: |
+    CopCo dataset :cite:p:`CopCoL1Hollenstein`.
+
+    This dataset includes monocular eye tracking data from a single participants in a single
+    session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+    eye tracker and are provided as pixel coordinates.
+
+    The participant is instructed to read texts and answer questions.
+
+    The dataset includes the data from three papers:
+        the L1 data: :cite:p:`CopCoL1Hollenstein`,
+        the L1 data with dylsexia: :cite:p:`CopCoL1DysBjornsdottir`,
+        the L2 data: :cite:p:`CopCoL2`,
+
+    If you use the dataset, please cite:
+      For L1:
+        @inproceedings{CopCoL1Hollenstein,
+          title = "The {C}openhagen Corpus of Eye Tracking Recordings from
+          Natural Reading of {D}anish Texts",
+          author = {Hollenstein, Nora  and
+            Barrett, Maria  and
+            Bj{\"o}rnsd{\'o}ttir, Marina},
+          editor = "Calzolari, Nicoletta  and
+            B{\'e}chet, Fr{\'e}d{\'e}ric  and
+            Blache, Philippe  and
+            Choukri, Khalid  and
+            Cieri, Christopher  and
+            Declerck, Thierry  and
+            Goggi, Sara  and
+            Isahara, Hitoshi  and
+            Maegaard, Bente  and
+            Mariani, Joseph  and
+            Mazo, H{\'e}l{\`e}ne  and
+            Odijk, Jan  and
+            Piperidis, Stelios",
+          booktitle = "Proceedings of the Thirteenth Language Resources and Evaluation Conference",
+          month = jun,
+          year = "2022",
+          address = "Marseille, France",
+          publisher = "European Language Resources Association",
+          url = "https://aclanthology.org/2022.lrec-1.182",
+          pages = "1712--1720",
+        }
+
+      For L1 with dyslexia:
+        @inproceedings{CopCoL1DysBjornsdottir,
+          title = "Dyslexia Prediction from Natural Reading of {D}anish Texts",
+          author = {Bj{\"o}rnsd{\'o}ttir, Marina  and
+            Hollenstein, Nora  and
+            Barrett, Maria},
+          editor = {Alum{\"a}e, Tanel  and
+            Fishel, Mark},
+          booktitle = "Proceedings of the 24th Nordic Conference on
+          Computational Linguistics (NoDaLiDa)",
+          month = may,
+          year = "2023",
+          address = "T{\'o}rshavn, Faroe Islands",
+          publisher = "University of Tartu Library",
+          url = "https://aclanthology.org/2023.nodalida-1.7",
+          pages = "60--70",
+        }
+      For L2:
+        @inproceedings{CopCoL2,
+          title = "Reading Does Not Equal Reading:
+          Comparing, Simulating and Exploiting Reading Behavior across Populations",
+          author = {Reich, David R.  and
+            Deng, Shuwen  and
+            Bj{\"o}rnsd{\'o}ttir, Marina  and
+            J{\"a}ger, Lena  and
+            Hollenstein, Nora},
+          editor = "Calzolari, Nicoletta  and
+            Kan, Min-Yen  and
+            Hoste, Veronique  and
+            Lenci, Alessandro  and
+            Sakti, Sakriani  and
+            Xue, Nianwen",
+          booktitle = "Proceedings of the 2024 Joint International Conference on
+          Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024)",
+          month = may,
+          year = "2024",
+          address = "Torino, Italia",
+          publisher = "ELRA and ICCL",
+          url = "https://aclanthology.org/2024.lrec-main.1187",
+          pages = "13586--13594",
+        }
+
 has_files:
   gaze: true
   precomputed_events: true

--- a/src/pymovements/datasets/daemons.py
+++ b/src/pymovements/datasets/daemons.py
@@ -49,6 +49,10 @@ class DAEMONS(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -102,6 +106,36 @@ class DAEMONS(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'DAEMONS'
+
+    info: str = """\
+DAEMONS dataset :cite:p:`DAEMONS`.
+
+The DAEMONS paper presents the Potsdam dataset of eye movements on natural scenes,
+aimed at advancing research in visual cognition and machine learning.
+It introduces a large-scale dataset with 2,400 images and eye-tracking data
+from 250 participants, ensuring high-quality data collection using
+state-of-the-art equipment. The study focuses on both fixation distributions
+and scan paths, making the dataset valuable for various modeling approaches,
+including saliency prediction and cognitive modeling.
+
+The dataset is split into train (precomputed_events[0]) and
+validation (precomputed_events[1]).
+
+Check the respective paper for details :cite:p:`DAEMONS`.
+
+If you use the dataset, please cite:
+
+@ARTICLE{DAEMONS,
+  AUTHOR={Schwetlick, Lisa  and Kümmerer, Matthias  and Bethge, Matthias  and Engbert, Ralf},
+  TITLE={Potsdam data set of eye movement on natural scenes (DAEMONS)},
+  JOURNAL={Frontiers in Psychology},
+  VOLUME={15},
+  YEAR={2024},
+  URL={https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2024.1389609},
+  DOI={10.3389/fpsyg.2024.1389609},
+  ISSN={1664-1078},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/daemons.yaml
+++ b/src/pymovements/datasets/daemons.yaml
@@ -1,5 +1,34 @@
 name: "DAEMONS"
 
+info: |
+    DAEMONS dataset :cite:p:`DAEMONS`.
+
+    The DAEMONS paper presents the Potsdam dataset of eye movements on natural scenes,
+    aimed at advancing research in visual cognition and machine learning.
+    It introduces a large-scale dataset with 2,400 images and eye-tracking data
+    from 250 participants, ensuring high-quality data collection using
+    state-of-the-art equipment. The study focuses on both fixation distributions
+    and scan paths, making the dataset valuable for various modeling approaches,
+    including saliency prediction and cognitive modeling.
+
+    The dataset is split into train (precomputed_events[0]) and
+    validation (precomputed_events[1]).
+
+    Check the respective paper for details :cite:p:`DAEMONS`.
+
+    If you use the dataset, please cite:
+
+    @ARTICLE{DAEMONS,
+      AUTHOR={Schwetlick, Lisa  and Kümmerer, Matthias  and Bethge, Matthias  and Engbert, Ralf},
+      TITLE={Potsdam data set of eye movement on natural scenes (DAEMONS)},
+      JOURNAL={Frontiers in Psychology},
+      VOLUME={15},
+      YEAR={2024},
+      URL={https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2024.1389609},
+      DOI={10.3389/fpsyg.2024.1389609},
+      ISSN={1664-1078},
+    }
+
 has_files:
   gaze: false
   precomputed_events: true

--- a/src/pymovements/datasets/didec.py
+++ b/src/pymovements/datasets/didec.py
@@ -45,6 +45,10 @@ class DIDEC(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -121,6 +125,38 @@ class DIDEC(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'DIDEC'
+
+    info: str = """\
+DIDEC dataset :cite:p:`DIDEC`.
+
+The DIDEC eye-tracking data has two different data collections, (1) for the
+description viewing task is more coherent than for the free-viewing task;
+(2) variation in image descriptions. The data was collected using BeGaze eye-tracker
+with a sampling rate of 250 Hz. The data collection contains 112 Dutch students,
+54 students completed the free viewing task, while 58 completed the image description task.
+
+Check the respective paper for details :cite:p:`DIDEC`.
+
+If you use the dataset, please cite:
+
+@inproceedings{DIDEC,
+    title = "{DIDEC}: The {D}utch Image Description and Eye-tracking Corpus",
+    author = "van Miltenburg, Emiel  and
+      K{\\'a}d{\\'a}r, {\\'A}kos  and
+      Koolen, Ruud  and
+      Krahmer, Emiel",
+    editor = "Bender, Emily M.  and
+      Derczynski, Leon  and
+      Isabelle, Pierre",
+    booktitle = "Proceedings of the 27th International Conference on Computational Linguistics",
+    month = aug,
+    year = "2018",
+    address = "Santa Fe, New Mexico, USA",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/C18-1310",
+    pages = "3658--3669",
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/didec.yaml
+++ b/src/pymovements/datasets/didec.yaml
@@ -1,5 +1,36 @@
 name: "DIDEC"
 
+info: |
+    DIDEC dataset :cite:p:`DIDEC`.
+
+    The DIDEC eye-tracking data has two different data collections, (1) for the
+    description viewing task is more coherent than for the free-viewing task;
+    (2) variation in image descriptions. The data was collected using BeGaze eye-tracker
+    with a sampling rate of 250 Hz. The data collection contains 112 Dutch students,
+    54 students completed the free viewing task, while 58 completed the image description task.
+
+    Check the respective paper for details :cite:p:`DIDEC`.
+
+    If you use the dataset, please cite:
+
+    @inproceedings{DIDEC,
+        title = "{DIDEC}: The {D}utch Image Description and Eye-tracking Corpus",
+        author = "van Miltenburg, Emiel  and
+          K{\'a}d{\'a}r, {\'A}kos  and
+          Koolen, Ruud  and
+          Krahmer, Emiel",
+        editor = "Bender, Emily M.  and
+          Derczynski, Leon  and
+          Isabelle, Pierre",
+        booktitle = "Proceedings of the 27th International Conference on Computational Linguistics",
+        month = aug,
+        year = "2018",
+        address = "Santa Fe, New Mexico, USA",
+        publisher = "Association for Computational Linguistics",
+        url = "https://aclanthology.org/C18-1310",
+        pages = "3658--3669",
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/emtec.py
+++ b/src/pymovements/datasets/emtec.py
@@ -45,6 +45,10 @@ class EMTeC(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -119,6 +123,29 @@ class EMTeC(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'EMTeC'
+
+    info: str = """\
+EMTeC dataset :cite:p:`EMTeC`.
+
+This dataset includes eye-tracking data from 107 native speakers of English reading
+machine generated texts.  Eye movements are recorded at a sampling frequency of 1,000 Hz
+using an EyeLink 1000 eye tracker and are provided as pixel coordinates.
+
+Check the respective paper for details :cite:p:`EMTeC`.
+
+If you use the dataset, please cite:
+
+@misc{EMTeC,
+  title={EMTeC: A Corpus of Eye Movements on Machine-Generated Texts},
+  author={Lena Sophia Bolliger and Patrick Haller and Isabelle Caroline Rose Cretton and
+  David Robert Reich and Tannon Kew and Lena Ann Jäger},
+  year={2024},
+  eprint={2408.04289},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL},
+  url={https://arxiv.org/abs/2408.04289},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/emtec.yaml
+++ b/src/pymovements/datasets/emtec.yaml
@@ -1,5 +1,27 @@
 name: "EMTeC"
 
+info: |
+    EMTeC dataset :cite:p:`EMTeC`.
+
+    This dataset includes eye-tracking data from 107 native speakers of English reading
+    machine generated texts.  Eye movements are recorded at a sampling frequency of 1,000 Hz
+    using an EyeLink 1000 eye tracker and are provided as pixel coordinates.
+
+    Check the respective paper for details :cite:p:`EMTeC`.
+
+    If you use the dataset, please cite:
+
+    @misc{EMTeC,
+      title={EMTeC: A Corpus of Eye Movements on Machine-Generated Texts},
+      author={Lena Sophia Bolliger and Patrick Haller and Isabelle Caroline Rose Cretton and
+      David Robert Reich and Tannon Kew and Lena Ann Jäger},
+      year={2024},
+      eprint={2408.04289},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2408.04289},
+    }
+
 has_files:
   gaze: true
   precomputed_events: true

--- a/src/pymovements/datasets/fakenews.py
+++ b/src/pymovements/datasets/fakenews.py
@@ -44,6 +44,10 @@ class FakeNewsPerception(DatasetDefinition):
     ----------
     name: str
         The name of the dataset.
+
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -72,6 +76,33 @@ class FakeNewsPerception(DatasetDefinition):
     """
 
     name: str = 'FakeNewsPerception'
+
+    info: str = """\
+FakeNewsPerception dataset :cite:p:`FakeNewsPerception`.
+
+FakeNewsPerception dataset consists of eye movements during reading,
+perceived believability scores, and questionnaires including Cognitive Reflection Test (CRT)
+and News-Find-Me (NFM) perception, collected from 25 participants with 60 news items.
+Eye movements are recorded to provide objective measures
+of information processing during news reading.
+
+For more details see :cite:p:`FakeNewsPerception`.
+
+If you use the dataset, please cite:
+
+@article{FakeNewsPerception,
+  author = {Sümer, Ömer and Bozkir, Efe and Kübler, Thomas and
+  Grüner, Sven and Utz, Sonja and Kasneci, Enkelejda},
+  year = {2021},
+  month = {03},
+  pages = {106909},
+  title = {FakeNewsPerception: An Eye Movement Dataset on the
+  Perceived Believability of News Stories},
+  volume = {35},
+  journal = {Data in Brief},
+  doi = {10.1016/j.dib.2021.106909,
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/fakenews.yaml
+++ b/src/pymovements/datasets/fakenews.yaml
@@ -1,5 +1,31 @@
 name: "FakeNewsPerception"
 
+info: |
+    FakeNewsPerception dataset :cite:p:`FakeNewsPerception`.
+
+    FakeNewsPerception dataset consists of eye movements during reading,
+    perceived believability scores, and questionnaires including Cognitive Reflection Test (CRT)
+    and News-Find-Me (NFM) perception, collected from 25 participants with 60 news items.
+    Eye movements are recorded to provide objective measures
+    of information processing during news reading.
+
+    For more details see :cite:p:`FakeNewsPerception`.
+
+    If you use the dataset, please cite:
+
+    @article{FakeNewsPerception,
+      author = {Sümer, Ömer and Bozkir, Efe and Kübler, Thomas and
+      Grüner, Sven and Utz, Sonja and Kasneci, Enkelejda},
+      year = {2021},
+      month = {03},
+      pages = {106909},
+      title = {FakeNewsPerception: An Eye Movement Dataset on the
+      Perceived Believability of News Stories},
+      volume = {35},
+      journal = {Data in Brief},
+      doi = {10.1016/j.dib.2021.106909,
+    }
+
 has_files:
   gaze: false
   precomputed_events: true

--- a/src/pymovements/datasets/gaze_graph.py
+++ b/src/pymovements/datasets/gaze_graph.py
@@ -51,6 +51,10 @@ class GazeGraph(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -128,6 +132,31 @@ class GazeGraph(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'GazeGraph'
+
+    info: str = """\
+GazeGraph dataset :cite:p:`GazeGraph`.
+
+The dataset is collected from eight subjects (four female and four male,
+aged between 24 and 35) using the Pupil Core eye tracker. During data collection,
+the subjects wear the eye tracker and sit in front of the computer screen
+(a 34-inch display) at a distance of approximately 50cm. We conduct the
+manufacturer's default on-screen five-points calibration for each of
+the subjects.
+Note that we have done only one calibration per subject, and the subjects
+can move their heads and upper bodies freely during the experiment.
+The gaze is recorded at a 30Hz sampling rate.
+
+Check the respective paper for details :cite:p:`GazeGraph`.
+
+If you use the dataset, please cite:
+
+@inproceedings{GazeGraph,
+  title={{GazeGraph}: Graph-based few-shot cognitive context sensing from human visual behavior},
+  author={Lan, Guohao and Heit, Bailey and Scargill, Tim and Gorlatova, Maria},
+  booktitle={Proceedings of the 18th ACM Conference on Embedded Networked Sensor Systems (SenSys)},
+  year={2020}
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/gaze_graph.yaml
+++ b/src/pymovements/datasets/gaze_graph.yaml
@@ -1,5 +1,29 @@
 name: "GazeGraph"
 
+info: |
+    GazeGraph dataset :cite:p:`GazeGraph`.
+
+    The dataset is collected from eight subjects (four female and four male,
+    aged between 24 and 35) using the Pupil Core eye tracker. During data collection,
+    the subjects wear the eye tracker and sit in front of the computer screen
+    (a 34-inch display) at a distance of approximately 50cm. We conduct the
+    manufacturer's default on-screen five-points calibration for each of
+    the subjects.
+    Note that we have done only one calibration per subject, and the subjects
+    can move their heads and upper bodies freely during the experiment.
+    The gaze is recorded at a 30Hz sampling rate.
+
+    Check the respective paper for details :cite:p:`GazeGraph`.
+
+    If you use the dataset, please cite:
+
+    @inproceedings{GazeGraph,
+      title={{GazeGraph}: Graph-based few-shot cognitive context sensing from human visual behavior},
+      author={Lan, Guohao and Heit, Bailey and Scargill, Tim and Gorlatova, Maria},
+      booktitle={Proceedings of the 18th ACM Conference on Embedded Networked Sensor Systems (SenSys)},
+      year={2020}
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/gaze_on_faces.py
+++ b/src/pymovements/datasets/gaze_on_faces.py
@@ -49,6 +49,10 @@ class GazeOnFaces(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -120,6 +124,34 @@ class GazeOnFaces(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'GazeOnFaces'
+
+    info: str = """\
+GazeOnFaces dataset :cite:p:`GazeOnFaces`.
+
+This dataset includes monocular eye tracking data from single participants in a single
+session. Eye movements are recorded at a sampling frequency of 60 Hz
+using an EyeLink 1000 video-based eye tracker and are provided as pixel coordinates.
+
+Participants were sat 57 cm away from the screen (19inch LCD monitor,
+screen res=1280×1024, 60 Hz). Recordings of the eye movements of one eye in monocular
+pupil/corneal reflection tracking mode.
+
+Check the respective paper for details :cite:p:`GazeOnFaces`.
+
+If you use the dataset, please cite:
+
+@article{GazeOnFaces,
+  title={Face exploration dynamics differentiate men and women},
+  author={Coutrot, Antoine and Binetti, Nicola and
+  Harrison, Charlotte and Mareschal, Isabelle and Johnston, Alan},
+  journal={Journal of vision},
+  volume={16},
+  number={14},
+  pages={16--16},
+  year={2016},
+  publisher={The Association for Research in Vision and Ophthalmology},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/gaze_on_faces.py
+++ b/src/pymovements/datasets/gaze_on_faces.py
@@ -34,7 +34,7 @@ from pymovements.gaze.experiment import Experiment
 class GazeOnFaces(DatasetDefinition):
     """GazeOnFaces dataset :cite:p:`GazeOnFaces`.
 
-    This dataset includes monocular eye tracking data from single participants in a single
+    This dataset includes monocular eye tracking data from several participants in a single
     session. Eye movements are recorded at a sampling frequency of 60 Hz
     using an EyeLink 1000 video-based eye tracker and are provided as pixel coordinates.
 
@@ -128,7 +128,7 @@ class GazeOnFaces(DatasetDefinition):
     info: str = """\
 GazeOnFaces dataset :cite:p:`GazeOnFaces`.
 
-This dataset includes monocular eye tracking data from single participants in a single
+This dataset includes monocular eye tracking data from several participants in a single
 session. Eye movements are recorded at a sampling frequency of 60 Hz
 using an EyeLink 1000 video-based eye tracker and are provided as pixel coordinates.
 

--- a/src/pymovements/datasets/gaze_on_faces.yaml
+++ b/src/pymovements/datasets/gaze_on_faces.yaml
@@ -3,7 +3,7 @@ name: "GazeOnFaces"
 info: |
     GazeOnFaces dataset :cite:p:`GazeOnFaces`.
 
-    This dataset includes monocular eye tracking data from single participants in a single
+    This dataset includes monocular eye tracking data from several participants in a single
     session. Eye movements are recorded at a sampling frequency of 60 Hz
     using an EyeLink 1000 video-based eye tracker and are provided as pixel coordinates.
 

--- a/src/pymovements/datasets/gaze_on_faces.yaml
+++ b/src/pymovements/datasets/gaze_on_faces.yaml
@@ -1,5 +1,32 @@
 name: "GazeOnFaces"
 
+info: |
+    GazeOnFaces dataset :cite:p:`GazeOnFaces`.
+
+    This dataset includes monocular eye tracking data from single participants in a single
+    session. Eye movements are recorded at a sampling frequency of 60 Hz
+    using an EyeLink 1000 video-based eye tracker and are provided as pixel coordinates.
+
+    Participants were sat 57 cm away from the screen (19inch LCD monitor,
+    screen res=1280×1024, 60 Hz). Recordings of the eye movements of one eye in monocular
+    pupil/corneal reflection tracking mode.
+
+    Check the respective paper for details :cite:p:`GazeOnFaces`.
+
+    If you use the dataset, please cite:
+
+    @article{GazeOnFaces,
+      title={Face exploration dynamics differentiate men and women},
+      author={Coutrot, Antoine and Binetti, Nicola and
+      Harrison, Charlotte and Mareschal, Isabelle and Johnston, Alan},
+      journal={Journal of vision},
+      volume={16},
+      number={14},
+      pages={16--16},
+      year={2016},
+      publisher={The Association for Research in Vision and Ophthalmology},
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/gazebase.py
+++ b/src/pymovements/datasets/gazebase.py
@@ -53,6 +53,10 @@ class GazeBase(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -125,6 +129,35 @@ class GazeBase(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'GazeBase'
+
+    info: str = """\
+GazeBase dataset :cite:p:`GazeBase`.
+
+This dataset includes monocular (left eye) eye tracking data from 322 participants captured over
+a period of 37 months. Participants attended up to 9 rounds during this time frame, with each
+round consisting of two contiguous sessions.
+
+Eye movements are recorded at a sampling frequency of 1000 Hz using an EyeLink 1000 video-based
+eye tracker and are provided as positional data in degrees of visual angle.
+
+In each of the two sessions per round, participants are instructed to complete a series of
+tasks, including a fixation task (FIX), a horizontal saccade task (HSS), a random saccade task
+(RAN), a reading task (TEX), two free viewing video tasks (VD1 and VD2) and a gaze-driven gaming
+task (BLG).
+
+Check the respective paper for details :cite:p:`GazeBase`.
+
+If you use the dataset, please cite:
+@article{GazeBase,
+  author = {Griffith, Henry and Lohr, Dillon and Abdulin, Evgeny and Komogortsev, Oleg},
+  year = {2021},
+  pages = {},
+  title = {{GazeBase}, a large-scale, multi-stimulus, longitudinal eye movement dataset},
+  volume = {8},
+  journal = {Scientific Data},
+  doi = {10.1038/s41597-021-00959-y},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/gazebase.yaml
+++ b/src/pymovements/datasets/gazebase.yaml
@@ -1,5 +1,33 @@
 name: "GazeBase"
 
+info: |
+    GazeBase dataset :cite:p:`GazeBase`.
+
+    This dataset includes monocular (left eye) eye tracking data from 322 participants captured over
+    a period of 37 months. Participants attended up to 9 rounds during this time frame, with each
+    round consisting of two contiguous sessions.
+
+    Eye movements are recorded at a sampling frequency of 1000 Hz using an EyeLink 1000 video-based
+    eye tracker and are provided as positional data in degrees of visual angle.
+
+    In each of the two sessions per round, participants are instructed to complete a series of
+    tasks, including a fixation task (FIX), a horizontal saccade task (HSS), a random saccade task
+    (RAN), a reading task (TEX), two free viewing video tasks (VD1 and VD2) and a gaze-driven gaming
+    task (BLG).
+
+    Check the respective paper for details :cite:p:`GazeBase`.
+
+    If you use the dataset, please cite:
+    @article{GazeBase,
+      author = {Griffith, Henry and Lohr, Dillon and Abdulin, Evgeny and Komogortsev, Oleg},
+      year = {2021},
+      pages = {},
+      title = {{GazeBase}, a large-scale, multi-stimulus, longitudinal eye movement dataset},
+      volume = {8},
+      journal = {Scientific Data},
+      doi = {10.1038/s41597-021-00959-y},
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/gazebasevr.py
+++ b/src/pymovements/datasets/gazebasevr.py
@@ -54,6 +54,10 @@ class GazeBaseVR(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -126,6 +130,38 @@ class GazeBaseVR(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'GazeBaseVR'
+
+    info: str = """\
+GazeBaseVR dataset :cite:p:`GazeBaseVR`.
+
+This dataset includes binocular plus an additional cyclopian eye tracking data from 407
+participants captured over a 26-month period. Participants attended up to 3 rounds during this
+time frame, with each round consisting of two contiguous sessions.
+
+Eye movements are recorded at a sampling frequency of 250 Hz a using SensoMotoric
+Instrument’s (SMI’s) tethered ET VR head-mounted display based on the
+HTC Vive (hereon called the ET-HMD) eye tracker and are provided as
+positional data in degrees of visual angle.
+
+In each of the two sessions per round, participants are instructed to complete a series of
+tasks, a vergence task (VRG), a smooth pursuit task (PUR), a video viewing task (VID),
+a reading task (TEX), and a random saccade task (RAN).
+
+Check the respective paper for details :cite:p:`GazeBaseVR`.
+
+If you use the dataset, please cite:
+
+@article{GazeBaseVR,
+  author = {Lohr, Dillon and Aziz, Samantha and Friedman, Lee and Komogortsev, Oleg},
+  year = {2023},
+  pages = {},
+  title = {{GazeBaseVR}, a large-scale, longitudinal, binocular eye-tracking
+  dataset collected in virtual reality},
+  volume = {10},
+  journal = {Scientific Data},
+  doi = {10.1038/s41597-023-02075-5},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/gazebasevr.yaml
+++ b/src/pymovements/datasets/gazebasevr.yaml
@@ -1,5 +1,36 @@
 name: "GazeBaseVR"
 
+info: |
+    GazeBaseVR dataset :cite:p:`GazeBaseVR`.
+
+    This dataset includes binocular plus an additional cyclopian eye tracking data from 407
+    participants captured over a 26-month period. Participants attended up to 3 rounds during this
+    time frame, with each round consisting of two contiguous sessions.
+
+    Eye movements are recorded at a sampling frequency of 250 Hz a using SensoMotoric
+    Instrument’s (SMI’s) tethered ET VR head-mounted display based on the
+    HTC Vive (hereon called the ET-HMD) eye tracker and are provided as
+    positional data in degrees of visual angle.
+
+    In each of the two sessions per round, participants are instructed to complete a series of
+    tasks, a vergence task (VRG), a smooth pursuit task (PUR), a video viewing task (VID),
+    a reading task (TEX), and a random saccade task (RAN).
+
+    Check the respective paper for details :cite:p:`GazeBaseVR`.
+
+    If you use the dataset, please cite:
+
+    @article{GazeBaseVR,
+      author = {Lohr, Dillon and Aziz, Samantha and Friedman, Lee and Komogortsev, Oleg},
+      year = {2023},
+      pages = {},
+      title = {{GazeBaseVR}, a large-scale, longitudinal, binocular eye-tracking
+      dataset collected in virtual reality},
+      volume = {10},
+      journal = {Scientific Data},
+      doi = {10.1038/s41597-023-02075-5},
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/hbn.py
+++ b/src/pymovements/datasets/hbn.py
@@ -48,6 +48,10 @@ class HBN(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -119,6 +123,55 @@ class HBN(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'HBN'
+
+    info: str = """\
+HBN dataset :cite:p:`HBN`.
+
+This dataset consists of recordings from children
+watching four different age-appropriate videos: (1) an
+educational video clip (Fun with Fractals), (2) a short animated
+film (The Present), (3) a short clip of an animated film (Despicable Me),
+and (4) a trailer for a feature-length movie (Diary of a Wimpy Kid).
+The eye gaze was recorded at a sampling rate of 120 Hz.
+
+Check the respective paper for details :cite:p:`HBN`.
+
+If you use the dataset, please cite:
+
+@article{HBN,
+  title={An open resource for transdiagnostic research in pediatric mental health
+  and learning disorders},
+  author={Alexander, Lindsay M. and Escalera, Jasmine and Ai, Lei and
+    Andreotti, Charissa and Febre, Karina and Mangone, Alexander and
+    Vega-Potler, Natan and Langer, Nicolas and Alexander, Alexis and
+    Kovacs, Meagan and Litke, Shannon and O'Hagan, Bridget and
+    Andersen, Jennifer and Bronstein, Batya and Bui, Anastasia and
+    Bushey, Marijayne and Butler, Henry and Castagna, Victoria and
+    Camacho, Nicolas and Chan, Elisha and Citera, Danielle and
+    Clucas, Jon and Cohen, Samantha and Dufek, Sarah and
+    Eaves, Megan and Fradera, Brian and Gardner, Judith and
+    Grant-Villegas, Natalie and Green, Gabriella and Gregory, Camille and
+    Hart, Emily and Harris, Shana and Horton, Megan and
+    Kahn, Danielle and Kabotyanski, Katherine and Karmel, Bernard and
+    Kelly, Simon P. and Kleinman, Kayla and Koo, Bonhwang and
+    Kramer, Eliza and Lennon, Elizabeth and Lord, Catherine and
+    Mantello, Ginny and Margolis, Amy and Merikangas, Kathleen R. and
+    Milham, Judith and Minniti, Giuseppe and Neuhaus, Rebecca and
+    Levine, Alexandra and Osman, Yael and Parra, Lucas C. and
+    Pugh, Ken R. and Racanello, Amy and Restrepo, Anita and
+    Saltzman, Tian and Septimus, Batya and Tobe, Russell and
+    Waltz, Rachel and Williams, Anna and Yeo, Anna and
+    Castellanos, Francisco X. and Klein, Arno and Paus, Tomas and
+    Leventhal, Bennett L. and Craddock, R. Cameron and Koplewicz, Harold S. and
+    Milham, Michael P.},
+  journal={Scientific data},
+  volume={4},
+  number={1},
+  pages={1--26},
+  year={2017},
+  publisher={Nature Publishing Group}
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/hbn.yaml
+++ b/src/pymovements/datasets/hbn.yaml
@@ -1,5 +1,53 @@
 name: "HBN"
 
+info: |
+    HBN dataset :cite:p:`HBN`.
+
+    This dataset consists of recordings from children
+    watching four different age-appropriate videos: (1) an
+    educational video clip (Fun with Fractals), (2) a short animated
+    film (The Present), (3) a short clip of an animated film (Despicable Me),
+    and (4) a trailer for a feature-length movie (Diary of a Wimpy Kid).
+    The eye gaze was recorded at a sampling rate of 120 Hz.
+
+    Check the respective paper for details :cite:p:`HBN`.
+
+    If you use the dataset, please cite:
+
+    @article{HBN,
+      title={An open resource for transdiagnostic research in pediatric mental health
+      and learning disorders},
+      author={Alexander, Lindsay M. and Escalera, Jasmine and Ai, Lei and
+        Andreotti, Charissa and Febre, Karina and Mangone, Alexander and
+        Vega-Potler, Natan and Langer, Nicolas and Alexander, Alexis and
+        Kovacs, Meagan and Litke, Shannon and O'Hagan, Bridget and
+        Andersen, Jennifer and Bronstein, Batya and Bui, Anastasia and
+        Bushey, Marijayne and Butler, Henry and Castagna, Victoria and
+        Camacho, Nicolas and Chan, Elisha and Citera, Danielle and
+        Clucas, Jon and Cohen, Samantha and Dufek, Sarah and
+        Eaves, Megan and Fradera, Brian and Gardner, Judith and
+        Grant-Villegas, Natalie and Green, Gabriella and Gregory, Camille and
+        Hart, Emily and Harris, Shana and Horton, Megan and
+        Kahn, Danielle and Kabotyanski, Katherine and Karmel, Bernard and
+        Kelly, Simon P. and Kleinman, Kayla and Koo, Bonhwang and
+        Kramer, Eliza and Lennon, Elizabeth and Lord, Catherine and
+        Mantello, Ginny and Margolis, Amy and Merikangas, Kathleen R. and
+        Milham, Judith and Minniti, Giuseppe and Neuhaus, Rebecca and
+        Levine, Alexandra and Osman, Yael and Parra, Lucas C. and
+        Pugh, Ken R. and Racanello, Amy and Restrepo, Anita and
+        Saltzman, Tian and Septimus, Batya and Tobe, Russell and
+        Waltz, Rachel and Williams, Anna and Yeo, Anna and
+        Castellanos, Francisco X. and Klein, Arno and Paus, Tomas and
+        Leventhal, Bennett L. and Craddock, R. Cameron and Koplewicz, Harold S. and
+        Milham, Michael P.},
+      journal={Scientific data},
+      volume={4},
+      number={1},
+      pages={1--26},
+      year={2017},
+      publisher={Nature Publishing Group}
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/interead.py
+++ b/src/pymovements/datasets/interead.py
@@ -45,6 +45,10 @@ class InteRead(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -123,6 +127,44 @@ class InteRead(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'InteRead'
+
+    info: str = """\
+InteRead dataset :cite:p:`InteRead`.
+
+This dataset includes monocular eye tracking data in an interrupted reading task.
+Automatic interruption occured during a reading task and participants continued
+reading after the pause.
+Eye movements are recorded at a sampling frequency of 1200Hz with video-based eye tracker.
+Provided data are raw gaze samples and precomputed event files both in pixel coordinates.
+
+For more details, check the paper :cite:p:`InteRead`.
+
+If you use the dataset, please cite:
+
+@inproceedings{InteRead,
+  title = {{I}nte{R}ead: An Eye Tracking Dataset of Interrupted Reading},
+  author = {Zermiani, Francesca  and
+    Dhar, Prajit  and
+    Sood, Ekta  and
+    K{\\"o}gel, Fabian  and
+    Bulling, Andreas  and
+    Wirzberger, Maria},
+  editor = {Calzolari, Nicoletta  and
+    Kan, Min-Yen  and
+    Hoste, Veronique  and
+    Lenci, Alessandro  and
+    Sakti, Sakriani  and
+    Xue, Nianwen},
+  booktitle = {Proceedings of the 2024 Joint International Conference on Computational Linguistics,
+  Language Resources and Evaluation (LREC-COLING 2024)},
+  month = may,
+  year = {2024},
+  address = {Torino, Italia},
+  publisher = {ELRA and ICCL},
+  url = {https://aclanthology.org/2024.lrec-main.802},
+  pages= {9154--9169},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/interead.yaml
+++ b/src/pymovements/datasets/interead.yaml
@@ -1,5 +1,42 @@
 name: "InteRead"
 
+info: |
+    InteRead dataset :cite:p:`InteRead`.
+
+    This dataset includes monocular eye tracking data in an interrupted reading task.
+    Automatic interruption occured during a reading task and participants continued
+    reading after the pause.
+    Eye movements are recorded at a sampling frequency of 1200Hz with video-based eye tracker.
+    Provided data are raw gaze samples and precomputed event files both in pixel coordinates.
+
+    For more details, check the paper :cite:p:`InteRead`.
+
+    If you use the dataset, please cite:
+
+    @inproceedings{InteRead,
+      title = {{I}nte{R}ead: An Eye Tracking Dataset of Interrupted Reading},
+      author = {Zermiani, Francesca  and
+        Dhar, Prajit  and
+        Sood, Ekta  and
+        K{\"o}gel, Fabian  and
+        Bulling, Andreas  and
+        Wirzberger, Maria},
+      editor = {Calzolari, Nicoletta  and
+        Kan, Min-Yen  and
+        Hoste, Veronique  and
+        Lenci, Alessandro  and
+        Sakti, Sakriani  and
+        Xue, Nianwen},
+      booktitle = {Proceedings of the 2024 Joint International Conference on Computational Linguistics,
+      Language Resources and Evaluation (LREC-COLING 2024)},
+      month = may,
+      year = {2024},
+      address = {Torino, Italia},
+      publisher = {ELRA and ICCL},
+      url = {https://aclanthology.org/2024.lrec-main.802},
+      pages= {9154--9169},
+    }
+
 has_files:
   gaze: true
   precomputed_events: true

--- a/src/pymovements/datasets/judo1000.py
+++ b/src/pymovements/datasets/judo1000.py
@@ -47,6 +47,10 @@ class JuDo1000(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -125,6 +129,28 @@ class JuDo1000(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'JuDo1000'
+
+    info: str = """\
+JuDo1000 dataset :cite:p:`JuDo1000`.
+
+This dataset includes binocular eye tracking data from 150 participants in four sessions with an
+interval of at least one week between two sessions. Eye movements are recorded at a sampling
+frequency of 1000 Hz using an EyeLink Portable Duo video-based eye tracker and are provided as
+pixel coordinates. Participants are instructed to watch a random jumping dot on a computer
+screen.
+
+Check the respective `repository <https://osf.io/5zpvk/>`_ for details.
+
+If you use the dataset, please cite:
+
+@misc{JuDo1000,
+  author = {Makowski, Silvia and Jäger, Lena A. and Prasse, Paul and Scheffer, Tobias},
+  title = {{JuDo1000} Eye Tracking Data Set},
+  year = {2020},
+  pages = {1-10},
+  doi = {10.17605/OSF.IO/5ZPVK},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/judo1000.yaml
+++ b/src/pymovements/datasets/judo1000.yaml
@@ -1,5 +1,26 @@
 name: "JuDo1000"
 
+info: |
+    JuDo1000 dataset :cite:p:`JuDo1000`.
+
+    This dataset includes binocular eye tracking data from 150 participants in four sessions with an
+    interval of at least one week between two sessions. Eye movements are recorded at a sampling
+    frequency of 1000 Hz using an EyeLink Portable Duo video-based eye tracker and are provided as
+    pixel coordinates. Participants are instructed to watch a random jumping dot on a computer
+    screen.
+
+    Check the respective `repository <https://osf.io/5zpvk/>`_ for details.
+
+    If you use the dataset, please cite:
+
+    @misc{JuDo1000,
+      author = {Makowski, Silvia and Jäger, Lena A. and Prasse, Paul and Scheffer, Tobias},
+      title = {{JuDo1000} Eye Tracking Data Set},
+      year = {2020},
+      pages = {1-10},
+      doi = {10.17605/OSF.IO/5ZPVK},
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/potec.py
+++ b/src/pymovements/datasets/potec.py
@@ -57,6 +57,10 @@ class PoTeC(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -125,6 +129,43 @@ class PoTeC(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'PoTeC'
+
+    info: str = """\
+PoTeC dataset :cite:p:`PoTeC`.
+
+The Potsdam Textbook Corpus (PoTeC) is a naturalistic eye-tracking-while-reading
+corpus containing data from 75 participants reading 12 scientific texts.
+PoTeC is the first naturalistic eye-tracking-while-reading corpus that contains
+eye-movements from domain-experts as well as novices in a within-participant
+manipulation: It is based on a 2×2×2 fully-crossed factorial design which includes
+the participants' level of study and the participants' discipline of study as
+between-subject factors and the text domain as a within-subject factor. The
+participants' reading comprehension was assessed by a series of text comprehension
+questions and their domain knowledge was tested by text-independent
+background questions for each of the texts. The materials are annotated for a
+variety of linguistic features at different levels. We envision PoTeC to be used
+for a wide range of studies including but not limited to analyses of expert and
+non-expert reading strategies.
+
+The corpus and all the accompanying data at all
+stages of the preprocessing pipeline and all code used to preprocess the data are
+made available via `GitHub. <https://github.com/DiLi-Lab/PoTeC>`_
+
+If you use the dataset, please cite:
+
+@misc{PoTeC,
+  url = {https://github.com/DiLi-Lab/PoTeC},
+  author = {
+  Jakobi, Deborah N. and
+  Kern, Thomas and
+  Reich, David R. and
+  Haller, Patrick and
+  J\\"ager, Lena A.},
+  title = {{PoTeC}: A {G}erman Naturalistic Eye-tracking-while-reading Corpus},
+  year = {2024},
+  note = {under review},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/potec.yaml
+++ b/src/pymovements/datasets/potec.yaml
@@ -1,5 +1,41 @@
 name: "PoTeC"
 
+info: |
+    PoTeC dataset :cite:p:`PoTeC`.
+
+    The Potsdam Textbook Corpus (PoTeC) is a naturalistic eye-tracking-while-reading
+    corpus containing data from 75 participants reading 12 scientific texts.
+    PoTeC is the first naturalistic eye-tracking-while-reading corpus that contains
+    eye-movements from domain-experts as well as novices in a within-participant
+    manipulation: It is based on a 2×2×2 fully-crossed factorial design which includes
+    the participants' level of study and the participants' discipline of study as
+    between-subject factors and the text domain as a within-subject factor. The
+    participants' reading comprehension was assessed by a series of text comprehension
+    questions and their domain knowledge was tested by text-independent
+    background questions for each of the texts. The materials are annotated for a
+    variety of linguistic features at different levels. We envision PoTeC to be used
+    for a wide range of studies including but not limited to analyses of expert and
+    non-expert reading strategies.
+
+    The corpus and all the accompanying data at all
+    stages of the preprocessing pipeline and all code used to preprocess the data are
+    made available via `GitHub. <https://github.com/DiLi-Lab/PoTeC>`_
+
+    If you use the dataset, please cite:
+
+    @misc{PoTeC,
+      url = {https://github.com/DiLi-Lab/PoTeC},
+      author = {
+      Jakobi, Deborah N. and
+      Kern, Thomas and
+      Reich, David R. and
+      Haller, Patrick and
+      J\"ager, Lena A.},
+      title = {{PoTeC}: A {G}erman Naturalistic Eye-tracking-while-reading Corpus},
+      year = {2024},
+      note = {under review},
+    }
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/provo.py
+++ b/src/pymovements/datasets/provo.py
@@ -47,6 +47,10 @@ class Provo(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -100,6 +104,36 @@ class Provo(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'Provo'
+
+    info: str = """\
+Provo dataset :cite:p:`Provo`.
+
+The Provo Corpus, a corpus of eye-tracking data with accompanying predictability norms.
+The predictability norms for the Provo Corpus differ from those of other corpora.
+In addition to traditional cloze scores that estimate the predictability of the full
+orthographic form of each word, the Provo Corpus also includes measures of the
+predictability of the morpho-syntactic and semantic information for each word.
+This makes the Provo Corpus ideal for studying predictive processes in reading.
+
+Check the respective paper for details :cite:p:`Provo`.
+
+If you use the dataset, please cite:
+
+@article{Provo,
+  author = {Luke, Steven G. and Christianson, Kiel},
+  address = {New York},
+  copyright = {Psychonomic Society, Inc. 2017},
+  issn = {1554-3528},
+  journal = {Behavior Research Methods},
+  language = {eng},
+  number = {2},
+  pages = {826-833},
+  publisher = {Springer US},
+  title = {The {P}rovo {C}orpus: A large eye-tracking corpus with predictability norms},
+  volume = {50},
+  year = {2018},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/provo.yaml
+++ b/src/pymovements/datasets/provo.yaml
@@ -1,5 +1,34 @@
 name: "Provo"
 
+info: |
+    Provo dataset :cite:p:`Provo`.
+
+    The Provo Corpus, a corpus of eye-tracking data with accompanying predictability norms.
+    The predictability norms for the Provo Corpus differ from those of other corpora.
+    In addition to traditional cloze scores that estimate the predictability of the full
+    orthographic form of each word, the Provo Corpus also includes measures of the
+    predictability of the morpho-syntactic and semantic information for each word.
+    This makes the Provo Corpus ideal for studying predictive processes in reading.
+
+    Check the respective paper for details :cite:p:`Provo`.
+
+    If you use the dataset, please cite:
+
+    @article{Provo,
+      author = {Luke, Steven G. and Christianson, Kiel},
+      address = {New York},
+      copyright = {Psychonomic Society, Inc. 2017},
+      issn = {1554-3528},
+      journal = {Behavior Research Methods},
+      language = {eng},
+      number = {2},
+      pages = {826-833},
+      publisher = {Springer US},
+      title = {The {P}rovo {C}orpus: A large eye-tracking corpus with predictability norms},
+      volume = {50},
+      year = {2018},
+    }
+
 has_files:
   gaze: false
   precomputed_events: true

--- a/src/pymovements/datasets/sb_sat.py
+++ b/src/pymovements/datasets/sb_sat.py
@@ -34,7 +34,7 @@ from pymovements.gaze.experiment import Experiment
 class SBSAT(DatasetDefinition):
     """SB-SAT dataset :cite:p:`SB-SAT`.
 
-    This dataset includes monocular eye tracking data from a single participants in a single
+    This dataset includes monocular eye tracking data from 75 participants in a single
     session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
     eye tracker and are provided as pixel coordinates.
 
@@ -132,7 +132,7 @@ class SBSAT(DatasetDefinition):
     info: str = """\
 SB-SAT dataset :cite:p:`SB-SAT`.
 
-This dataset includes monocular eye tracking data from a single participants in a single
+This dataset includes monocular eye tracking data from 75 participants in a single
 session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
 eye tracker and are provided as pixel coordinates.
 

--- a/src/pymovements/datasets/sb_sat.py
+++ b/src/pymovements/datasets/sb_sat.py
@@ -47,6 +47,10 @@ class SBSAT(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -125,6 +129,29 @@ class SBSAT(DatasetDefinition):
 
     name: str = 'SBSAT'
 
+    info: str = """\
+SB-SAT dataset :cite:p:`SB-SAT`.
+
+This dataset includes monocular eye tracking data from a single participants in a single
+session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+eye tracker and are provided as pixel coordinates.
+
+The participant is instructed to read texts and answer questions.
+
+Check the respective paper for details :cite:p:`SB-SAT`.
+
+If you use the dataset, please cite:
+
+@inproceedings{SB-SAT,
+  title = {Towards predicting reading comprehension from gaze behavior},
+  year = {2020},
+  booktitle = {Proceedings of the ACM Symposium on Eye Tracking Research and Applications},
+  author = {Ahn, Seoyoung and Kelton, Conor and Balasubramanian, Aruna and Zelinsky, Greg},
+  pages = {1--5},
+  publisher = {Association for Computing Machinery},
+  address = "Stuttgart, Germany",
+}
+"""
     has_files: dict[str, bool] = field(
         default_factory=lambda: {
             'gaze': True,

--- a/src/pymovements/datasets/sb_sat.yaml
+++ b/src/pymovements/datasets/sb_sat.yaml
@@ -3,7 +3,7 @@ name: SBSAT
 info: |
     SB-SAT dataset :cite:p:`SB-SAT`.
 
-    This dataset includes monocular eye tracking data from a single participants in a single
+    This dataset includes monocular eye tracking data from 75 participants in a single
     session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
     eye tracker and are provided as pixel coordinates.
 

--- a/src/pymovements/datasets/sb_sat.yaml
+++ b/src/pymovements/datasets/sb_sat.yaml
@@ -1,5 +1,28 @@
 name: SBSAT
 
+info: |
+    SB-SAT dataset :cite:p:`SB-SAT`.
+
+    This dataset includes monocular eye tracking data from a single participants in a single
+    session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
+    eye tracker and are provided as pixel coordinates.
+
+    The participant is instructed to read texts and answer questions.
+
+    Check the respective paper for details :cite:p:`SB-SAT`.
+
+    If you use the dataset, please cite:
+
+    @inproceedings{SB-SAT,
+      title = {Towards predicting reading comprehension from gaze behavior},
+      year = {2020},
+      booktitle = {Proceedings of the ACM Symposium on Eye Tracking Research and Applications},
+      author = {Ahn, Seoyoung and Kelton, Conor and Balasubramanian, Aruna and Zelinsky, Greg},
+      pages = {1--5},
+      publisher = {Association for Computing Machinery},
+      address = "Stuttgart, Germany",
+    }
+
 has_files:
   gaze: true
   precomputed_events: true

--- a/src/pymovements/datasets/toy_dataset.py
+++ b/src/pymovements/datasets/toy_dataset.py
@@ -45,6 +45,10 @@ class ToyDataset(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -116,6 +120,16 @@ class ToyDataset(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'ToyDataset'
+
+    info: str = """\
+Example toy dataset.
+
+This dataset includes monocular eye tracking data from a single participants in a single
+session. Eye movements are recorded at a sampling frequency of 1000 Hz using an EyeLink Portable
+Duo video-based eye tracker and are provided as pixel coordinates.
+
+The participant is instructed to read 4 texts with 5 screens each.
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/toy_dataset.yaml
+++ b/src/pymovements/datasets/toy_dataset.yaml
@@ -1,5 +1,14 @@
 name: "ToyDataset"
 
+info: |
+    Example toy dataset.
+
+    This dataset includes monocular eye tracking data from a single participants in a single
+    session. Eye movements are recorded at a sampling frequency of 1000 Hz using an EyeLink Portable
+    Duo video-based eye tracker and are provided as pixel coordinates.
+
+    The participant is instructed to read 4 texts with 5 screens each.
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -46,6 +46,10 @@ class ToyDatasetEyeLink(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -117,6 +121,16 @@ class ToyDatasetEyeLink(DatasetDefinition):
     # The DatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'ToyDatasetEyeLink'
+
+    info: str = """\
+Example toy dataset with EyeLink data.
+
+This dataset includes monocular eye tracking data from a single participants in a single
+session. Eye movements are recorded at a sampling frequency of 1000 Hz using an EyeLink Portable
+Duo video-based eye tracker and are provided as pixel coordinates.
+
+The participant is instructed to read a single text and some JuDo trials.
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/toy_dataset_eyelink.yaml
+++ b/src/pymovements/datasets/toy_dataset_eyelink.yaml
@@ -1,5 +1,14 @@
 name: "ToyDatasetEyeLink"
 
+info: |
+    Example toy dataset with EyeLink data.
+
+    This dataset includes monocular eye tracking data from a single participants in a single
+    session. Eye movements are recorded at a sampling frequency of 1000 Hz using an EyeLink Portable
+    Duo video-based eye tracker and are provided as pixel coordinates.
+
+    The participant is instructed to read a single text and some JuDo trials.
+
 has_files:
   gaze: true
   precomputed_events: false

--- a/src/pymovements/datasets/ucl.py
+++ b/src/pymovements/datasets/ucl.py
@@ -44,6 +44,10 @@ class UCL(DatasetDefinition):
     name: str
         The name of the dataset.
 
+    info: str
+        Information about the dataset including but not limited to original citation,
+        general information.
+
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -97,6 +101,35 @@ class UCL(DatasetDefinition):
     # The PublicDatasetDefinition child classes potentially share code chunks for definitions.
 
     name: str = 'UCL'
+
+    info: str = """\
+UCL dataset :cite:p:`UCL`.
+
+UCL is a dataset of word-by-word reading times collected through
+self-paced reading and eye-tracking experiments to evaluate
+computational psycholinguistic models of English sentence comprehension.
+361 sentences from narrative sources, ensuring they were understandable without context,
+and recorded reading times from participants using both methods.
+
+For more details check out the original paper :cite:p:`UCL`.
+
+If you use the dataset, please cite:
+
+@article{UCL,
+  author = {
+      Frank, Stefan L. and
+      Fernandez Monsalve, Irene and
+      Thompson, Robin L. and
+      Vigliocco, Gabriella
+  },
+  year = {2013},
+  title = {Reading time data for evaluating broad-coverage models of {E}nglish sentence processing},
+  journal = {Behavior Research Methods},
+  volume = {45},
+  issue = {4},
+  doi = {10.3758/s13428-012-0313-y},
+}
+"""
 
     has_files: dict[str, bool] = field(
         default_factory=lambda: {

--- a/src/pymovements/datasets/ucl.yaml
+++ b/src/pymovements/datasets/ucl.yaml
@@ -1,5 +1,33 @@
 name: "UCL"
 
+info: |
+    UCL dataset :cite:p:`UCL`.
+
+    UCL is a dataset of word-by-word reading times collected through
+    self-paced reading and eye-tracking experiments to evaluate
+    computational psycholinguistic models of English sentence comprehension.
+    361 sentences from narrative sources, ensuring they were understandable without context,
+    and recorded reading times from participants using both methods.
+
+    For more details check out the original paper :cite:p:`UCL`.
+
+    If you use the dataset, please cite:
+
+    @article{UCL,
+      author = {
+          Frank, Stefan L. and
+          Fernandez Monsalve, Irene and
+          Thompson, Robin L. and
+          Vigliocco, Gabriella
+      },
+      year = {2013},
+      title = {Reading time data for evaluating broad-coverage models of {E}nglish sentence processing},
+      journal = {Behavior Research Methods},
+      volume = {45},
+      issue = {4},
+      doi = {10.3758/s13428-012-0313-y},
+    }
+
 has_files:
   gaze: false
   precomputed_events: true

--- a/tests/unit/dataset/dataset_library_test.py
+++ b/tests/unit/dataset/dataset_library_test.py
@@ -88,7 +88,7 @@ def test_dataset_library_contains_all_public_datasets_files():
         dataset_path = Path(filename)
         if dataset_path.name == 'datasets.yaml':
             continue
-        with open(filename, encoding='ascii') as f:
+        with open(filename, encoding='utf-8') as f:
             dataset_file = yaml.safe_load(f)
         dataset_name = dataset_file['name']
         assert dataset_name in library, f'please add {dataset_name} to `datasets.yaml`'

--- a/tests/unit/dataset/dataset_test.py
+++ b/tests/unit/dataset/dataset_test.py
@@ -2018,3 +2018,11 @@ def test_load_split_gaze(gaze_dataset_configuration, by, expected_len):
     dataset.load()
     dataset.split_gaze_data(by)
     assert len(dataset.gaze) == expected_len
+
+
+def test_dataset_info(capsys):
+    dataset = pm.Dataset('ToyDataset', 'data')
+    dataset.info
+    outerr = capsys.readouterr().out
+    assert 'includes monocular eye tracking data' in outerr
+    assert 'to read 4 texts with 5 screens each.' in outerr


### PR DESCRIPTION
add information about the dataset as a property.  

additionally, resolves #987. 

a final version of info `property` could be integrated into the download process, to make the user aware of the underlying information and citation. 