### PR TITLE
ci: remove xfails for #475 as they pass

### DIFF
--- a/tests/unit/gaze/transforms/pos2acc_test.py
+++ b/tests/unit/gaze/transforms/pos2acc_test.py
@@ -119,7 +119,6 @@ def test_pos2acc_raises_error(kwargs, series, exception, msg_substrings):
             pl.Series('position', [], pl.List(pl.Float64)),
             pl.Series('acceleration', [], pl.List(pl.Float64)),
             id='empty_series_returns_empty_series',
-            marks=pytest.mark.xfail(reason='#475'),
         ),
         pytest.param(
             {'window_length': 3, 'degree': 1, 'sampling_rate': 1, 'n_components': 2},

--- a/tests/unit/gaze/transforms/pos2vel_test.py
+++ b/tests/unit/gaze/transforms/pos2vel_test.py
@@ -165,7 +165,6 @@ def test_pos2vel_raises_error(kwargs, series, exception, msg_substrings):
             pl.Series('position', [], pl.List(pl.Float64)),
             pl.Series('velocity', [], pl.List(pl.Float64)),
             id='empty_series_raises_compute_error',
-            marks=pytest.mark.xfail(reason='#475'),
         ),
         pytest.param(
             {

--- a/tests/unit/gaze/transforms/savitzky_golay_test.py
+++ b/tests/unit/gaze/transforms/savitzky_golay_test.py
@@ -172,7 +172,6 @@ def test_savitzky_golay_raises_error(kwargs, series, exception, msg_substrings):
             pl.Series('A', [], pl.List(pl.Float64)),
             pl.Series('A', [], pl.List(pl.Float64)),
             id='empty_series_returns_empty_series',
-            marks=pytest.mark.xfail(reason='#475'),
         ),
         pytest.param(
             {


### PR DESCRIPTION
## Description

Some of the xfails for our transforms are passing for a while now. This was probably fixed on the polars side. I removed the xfails accordingly.

Fixes #475
