### PR TITLE
docs: add source button to sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -202,7 +202,7 @@ def linkcode_resolve(domain, info):
         return None
 
     modname = info['module']
-    modname.split('.')[0]
+    topmodulename = modname.split('.')[0]
     fullname = info['fullname']
 
     submod = sys.modules.get(modname)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,10 +118,10 @@ html_css_files = [
 
 html_theme_options = {
     'navigation_with_keys': True,
-    
-    "repository_url": "https://github.com/aeye-lab/pymovements",
-    "use_source_button": True,
-    
+
+    'repository_url': 'https://github.com/aeye-lab/pymovements',
+    'use_source_button': True,
+
     'external_links': [
         {
             'name': 'Contributing',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,8 @@ from pybtex.plugin import register_plugin
 from pybtex.style.formatting.plain import Style as PlainStyle
 from pybtex.style.labels import BaseLabelStyle
 
+import pymovements
+
 # add relative source path to python path
 sys.path.insert(0, os.path.abspath('src'))
 sys.path.insert(0, os.path.dirname(os.path.abspath('src')))
@@ -117,11 +119,7 @@ html_css_files = [
 ]
 
 html_theme_options = {
-    'navigation_with_keys': True,
-
-    'repository_url': 'https://github.com/aeye-lab/pymovements',
-    'use_source_button': True,
-
+    'navigation_with_keys': False,
     'external_links': [
         {
             'name': 'Contributing',
@@ -196,7 +194,7 @@ extlinks = {
 
 LINKCODE_URL = (
     f'https://github.com/aeye-lab/pymovements/blob/{REVISION}'
-    '/src/{filepath}#L{linestart}-L{linestop}'
+    '/src/pymovements/{filepath}#L{linestart}-L{linestop}'
 )
 
 
@@ -221,8 +219,10 @@ def linkcode_resolve(domain, info):
             return None
 
     try:
-        modpath = importlib.resources.require(topmodulename)[0].location
-        filepath = os.path.relpath(inspect.getsourcefile(obj), modpath)
+        filepath = os.path.relpath(
+            inspect.getsourcefile(obj),
+            os.path.dirname(pymovements.__file__),
+        )
         if filepath is None:
             return
     except Exception:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -202,7 +202,7 @@ def linkcode_resolve(domain, info):
         return None
 
     modname = info['module']
-    topmodulename = modname.split('.')[0]
+    modname.split('.')[0]
     fullname = info['fullname']
 
     submod = sys.modules.get(modname)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import importlib.resources
 import inspect
 import os
 import sys
@@ -204,7 +203,7 @@ def linkcode_resolve(domain, info):
         return None
 
     modname = info['module']
-    topmodulename = modname.split('.')[0]
+    modname.split('.')[0]
     fullname = info['fullname']
 
     submod = sys.modules.get(modname)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import importlib.resources
 import inspect
 import os
 import sys
@@ -36,8 +37,6 @@ from subprocess import run
 from pybtex.plugin import register_plugin
 from pybtex.style.formatting.plain import Style as PlainStyle
 from pybtex.style.labels import BaseLabelStyle
-
-import pymovements
 
 # add relative source path to python path
 sys.path.insert(0, os.path.abspath('src'))
@@ -203,7 +202,7 @@ def linkcode_resolve(domain, info):
         return None
 
     modname = info['module']
-    modname.split('.')[0]
+    topmodulename = modname.split('.')[0]
     fullname = info['fullname']
 
     submod = sys.modules.get(modname)
@@ -220,7 +219,7 @@ def linkcode_resolve(domain, info):
     try:
         filepath = os.path.relpath(
             inspect.getsourcefile(obj),
-            os.path.dirname(pymovements.__file__),
+            importlib.resources.files('pymovements'),
         )
         if filepath is None:
             return

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -217,10 +217,8 @@ def linkcode_resolve(domain, info):
             return None
 
     try:
-        filepath = os.path.relpath(
-            inspect.getsourcefile(obj),
-            importlib.resources.files('pymovements'),
-        )
+        modpath = importlib.resources.files(topmodulename)
+        filepath = os.path.relpath(inspect.getsourcefile(obj), modpath)
         if filepath is None:
             return
     except Exception:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,7 +117,11 @@ html_css_files = [
 ]
 
 html_theme_options = {
-    'navigation_with_keys': False,
+    'navigation_with_keys': True,
+    
+    "repository_url": "https://github.com/aeye-lab/pymovements",
+    "use_source_button": True,
+    
     'external_links': [
         {
             'name': 'Contributing',


### PR DESCRIPTION
## Description

This fixes the missing source button in our sphinx docs.

We broke it in #660 when migrating to python3.12 and removing `pkg_resources`.

`importlib.resources` has no `require()` method, but you can get the path to the top-module via `files()`.

The function failed silently and therefore returned `None`, leading to the missing source button.


Fixes #1066

## Implemented changes

- [x] Correctly get module path in `linkcode_resolve` of `/docs/source/conf.py`

