### PR TITLE
dataset: add trial_columns to ToyDatasetEyeLink

### DIFF
--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -78,7 +78,7 @@ class ToyDatasetEyeLink(DatasetDefinition):
             The name of the trial columns in the input data frame. If the list is empty or None,
             the input data frame is assumed to contain only one trial. If the list is not empty,
             the input data frame is assumed to contain multiple trials and the transformation
-            methods will be applied to each trial separately. (default: None)
+            methods will be applied to each trial separately.
 
     time_column: str
         The name of the timestamp column in the input data frame. This column will be renamed to

--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -74,6 +74,12 @@ class ToyDatasetEyeLink(DatasetDefinition):
         If named groups are present in the `filename_format`, this makes it possible to cast
         specific named groups to a particular datatype.
 
+    trial_columns: list[str]
+            The name of the trial columns in the input data frame. If the list is empty or None,
+            the input data frame is assumed to contain only one trial. If the list is not empty,
+            the input data frame is assumed to contain multiple trials and the transformation
+            methods will be applied to each trial separately. (default: None)
+
     time_column: str
         The name of the timestamp column in the input data frame. This column will be renamed to
         ``time``.
@@ -180,6 +186,10 @@ class ToyDatasetEyeLink(DatasetDefinition):
                 'session_id': int,
             },
         },
+    )
+
+    trial_columns: list[str] = field(
+        default_factory=lambda: ['task', 'trial_id', 'screen_id', 'point_id'],
     )
 
     time_column: str = 'time'

--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -189,7 +189,7 @@ class ToyDatasetEyeLink(DatasetDefinition):
     )
 
     trial_columns: list[str] = field(
-        default_factory=lambda: ['task', 'trial_id', 'screen_id', 'point_id'],
+        default_factory=lambda: ['task', 'trial_id'],
     )
 
     time_column: str = 'time'

--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -188,7 +188,7 @@ class ToyDatasetEyeLink(DatasetDefinition):
         },
     )
 
-    trial_columns: list[str] = field(
+    trial_columns: list[str] | None = field(
         default_factory=lambda: ['task', 'trial_id'],
     )
 

--- a/src/pymovements/datasets/toy_dataset_eyelink.py
+++ b/src/pymovements/datasets/toy_dataset_eyelink.py
@@ -74,7 +74,7 @@ class ToyDatasetEyeLink(DatasetDefinition):
         If named groups are present in the `filename_format`, this makes it possible to cast
         specific named groups to a particular datatype.
 
-    trial_columns: list[str]
+    trial_columns: list[str] | None
             The name of the trial columns in the input data frame. If the list is empty or None,
             the input data frame is assumed to contain only one trial. If the list is not empty,
             the input data frame is assumed to contain multiple trials and the transformation

--- a/src/pymovements/datasets/toy_dataset_eyelink.yaml
+++ b/src/pymovements/datasets/toy_dataset_eyelink.yaml
@@ -43,8 +43,6 @@ filename_format_schema_overrides:
 trial_columns:
   - task
   - trial_id
-  - screen_id
-  - point_id
 
 time_column: "time"
 

--- a/src/pymovements/datasets/toy_dataset_eyelink.yaml
+++ b/src/pymovements/datasets/toy_dataset_eyelink.yaml
@@ -40,6 +40,12 @@ filename_format_schema_overrides:
     subject_id: !int
     session_id: !int
 
+trial_columns:
+  - task
+  - trial_id
+  - screen_id
+  - point_id
+
 time_column: "time"
 
 time_unit: "ms"


### PR DESCRIPTION
## Description

the dataset was missing the trial columns. I noticed it in #1004 and updated and tested it there, but probably it's better to have a separate PR for the dataset definition change.

## Implemented changes

- [x] added `trial_columns` to `ToyDatasetEyeLink` python class
- [x] added `trial_columns` to `ToyDatasetEyeLink` yaml file

## How Has This Been Tested?

- [x] Tests are written in #1004 with new functionality.
        I wouldn't like to rewrite the tests with the old-style explicit argument passing for this PR here.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
