### PR TITLE
ci: set fail-fast to false in integration tests

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare-matrix]
     strategy:
+      fail-fast: false
       matrix:
         dataset: ${{ fromJSON(needs.prepare-matrix.outputs.all_datasets) }}
     steps:


### PR DESCRIPTION
## Description

`fail-fast` is `true` by default, which leads to cancelled integration tests if one of the datasets fails. This PR sets `fail-fast` to `false`.