### PR TITLE
feat: make `DatasetDefinition.long_name` optional

### DIFF
--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -1108,7 +1108,7 @@ class Dataset:
         if len(self.gaze) == 0:
             raise AttributeError('no files present in gaze attribute')
 
-    def _disclaimer() -> str:
+    def _disclaimer(self) -> str:
         """Return string for dataset download disclaimer."""
         if self.definition.long_name is not None:
             dataset_name = self.definition.long_name

--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -1004,7 +1004,7 @@ class Dataset:
             If downloading a resource failed for all given mirrors.
         """
         logger.info(self._disclaimer())
-        
+
         dataset_download.download_dataset(
             definition=self.definition,
             paths=self.paths,

--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -20,6 +20,7 @@
 """Provides the Dataset class."""
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from collections.abc import Sequence
 from copy import deepcopy
@@ -38,6 +39,10 @@ from pymovements.events import EventDataFrame
 from pymovements.events.precomputed import PrecomputedEventDataFrame
 from pymovements.gaze import GazeDataFrame
 from pymovements.reading_measures import ReadingMeasures
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class Dataset:
@@ -998,6 +1003,17 @@ class Dataset:
         RuntimeError
             If downloading a resource failed for all given mirrors.
         """
+        dataset_name = self.definition.long_name if not None else self.definition.name
+
+        disclaimer_text = f"""\
+        You are downloading the {dataset_name}. Please be aware that pymovements does not
+        host or distribute any dataset resources and only provides a convenient interface to
+        download the public dataset resources that were published by their respective authors.
+
+        Please cite the referenced publication if you intend to use the dataset in your research.
+        """
+        logger.info(disclaimer_text)
+
         dataset_download.download_dataset(
             definition=self.definition,
             paths=self.paths,

--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -1003,7 +1003,10 @@ class Dataset:
         RuntimeError
             If downloading a resource failed for all given mirrors.
         """
-        dataset_name = self.definition.long_name if not None else self.definition.name
+        if self.definition.long_name is not None:
+            dataset_name = self.definition.long_name
+        else:
+            dataset_name = self.definition.name
 
         disclaimer_text = f"""\
         You are downloading the {dataset_name}. Please be aware that pymovements does not

--- a/src/pymovements/dataset/dataset.py
+++ b/src/pymovements/dataset/dataset.py
@@ -1003,20 +1003,8 @@ class Dataset:
         RuntimeError
             If downloading a resource failed for all given mirrors.
         """
-        if self.definition.long_name is not None:
-            dataset_name = self.definition.long_name
-        else:
-            dataset_name = self.definition.name
-
-        disclaimer_text = f"""\
-        You are downloading the {dataset_name}. Please be aware that pymovements does not
-        host or distribute any dataset resources and only provides a convenient interface to
-        download the public dataset resources that were published by their respective authors.
-
-        Please cite the referenced publication if you intend to use the dataset in your research.
-        """
-        logger.info(disclaimer_text)
-
+        logger.info(self._disclaimer())
+        
         dataset_download.download_dataset(
             definition=self.definition,
             paths=self.paths,
@@ -1119,3 +1107,18 @@ class Dataset:
             raise AttributeError('gaze files were not loaded yet. please run load() beforehand')
         if len(self.gaze) == 0:
             raise AttributeError('no files present in gaze attribute')
+
+    def _disclaimer() -> str:
+        """Return string for dataset download disclaimer."""
+        if self.definition.long_name is not None:
+            dataset_name = self.definition.long_name
+        else:
+            dataset_name = self.definition.name + ' dataset'
+
+        return f"""\
+        You are downloading the {dataset_name}. Please be aware that pymovements does not
+        host or distribute any dataset resources and only provides a convenient interface to
+        download the public dataset resources that were published by their respective authors.
+
+        Please cite the referenced publication if you intend to use the dataset in your research.
+        """

--- a/src/pymovements/dataset/dataset_definition.py
+++ b/src/pymovements/dataset/dataset_definition.py
@@ -47,8 +47,8 @@ class DatasetDefinition:
     ----------
     name: str
         The name of the dataset. (default: '.')
-    long_name: str
-        The entire name of the dataset. (default: '.')
+    long_name: str | None
+        The entire name of the dataset. (default: None)
     has_files: dict[str, bool]
         Indicate whether the dataset contains 'gaze', 'precomputed_events', and
         'precomputed_reading_measures'.
@@ -145,7 +145,7 @@ class DatasetDefinition:
     # pylint: disable=too-many-instance-attributes
     name: str = '.'
 
-    long_name: str = '.'
+    long_name: str | None = None
 
     has_files: dict[str, bool] = field(default_factory=dict)
 

--- a/src/pymovements/dataset/dataset_download.py
+++ b/src/pymovements/dataset/dataset_download.py
@@ -20,7 +20,6 @@
 """Provides private functions for downloading and extracting datasets."""
 from __future__ import annotations
 
-import logging
 import shutil
 from pathlib import Path
 from urllib.error import URLError
@@ -30,10 +29,6 @@ from pymovements.dataset._utils._archives import extract_archive
 from pymovements.dataset._utils._downloads import download_file
 from pymovements.dataset.dataset_definition import DatasetDefinition
 from pymovements.dataset.dataset_paths import DatasetPaths
-
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 
 def download_dataset(
@@ -82,15 +77,6 @@ def download_dataset(
     RuntimeError
         If downloading a resource failed for all given mirrors.
     """
-    disclaimer_text = f"""\
-You are downloading the {definition.long_name}. Please be aware that pymovements does not
-host or distribute any dataset resources and only provides a convenient interface to
-download the public dataset resources that were published by their respective authors.
-
-Please cite the referenced publication if you intend to use the dataset in your research.
-"""
-    logger.info(disclaimer_text)
-
     if definition.has_files['gaze']:
         if not definition.mirrors or not definition.mirrors['gaze']:
             mirrors = None

--- a/tests/unit/dataset/dataset_definition_test.py
+++ b/tests/unit/dataset/dataset_definition_test.py
@@ -183,7 +183,7 @@ def test_dataset_definition_to_dict_expected(definition, expected_dict):
             True,
             {
                 'name': 'MyDatasetDefinition',
-                'long_name': '.',
+                'long_name': None,
                 'has_files': {},
                 'acceleration_columns': None,
                 'column_map': {},
@@ -227,7 +227,7 @@ def test_dataset_definition_to_dict_expected(definition, expected_dict):
             False,
             {
                 'name': 'MyDatasetDefinition',
-                'long_name': '.',
+                'long_name': None,
                 '_foobar': 'test',
                 'has_files': {},
                 'acceleration_columns': None,


### PR DESCRIPTION
## Description

Make `DatasetDefinition.long_name` optional and use `DatasetDefinition.name` in disclaimer in case `DatasetDefinition.long_name` is `None`.

## Implemented changes

- [x] move disclaimer to `Dataset._disclaimer()` and log in `Dataset.download()`
- [x] change attribute to `Dataset.long_name: str | None = None`

## How Has This Been Tested?

No additional tests written. I should probably write at least two tests.

## Type of change

- New functionality

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
