### PR TITLE
ci: reduce CI compute by canceling outdated runs in PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: test ${{ matrix.tox_env }} (${{ matrix.os }})


### PR DESCRIPTION
## Description

Cancels workflow runs if a newer commit is available to reduce compute. Cancelling is only applied on pull requests, not on main branch.