### PR TITLE
feat: split EventDataFrame by column

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,7 @@ repos:
     rev: v2.3.2
     hooks:
     -   id: autopep8
+        args: [--global-config=.flake8]
 -   repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1
     hooks:

--- a/src/pymovements/events/frame.py
+++ b/src/pymovements/events/frame.py
@@ -269,6 +269,37 @@ class EventDataFrame:
         """
         return EventDataFrame(data=self.frame.clone())
 
+    def split(self, by: Sequence[str]) -> list[EventDataFrame]:
+        """Split the EventDataFrame into multiple frames based on specified column(s).
+
+        Parameters
+        ----------
+        by: Sequence[str]
+            Column name(s) to split the DataFrame by. If a single string is provided,
+            it will be used as a single column name. If a list is provided, the DataFrame
+            will be split by unique combinations of values in all specified columns.
+
+        Returns
+        -------
+        list[EventDataFrame]
+            A list of new EventDataFrame instances, each containing a partition of the
+            original data with all metadata and configurations preserved.
+        """
+        event_pl_df_list = list(self.frame.partition_by(by=by))
+
+        # Ensure column order: trial columns, name, onset, offset.
+        if self.trial_columns is not None:
+            event_pl_df_list = [
+                frame.select([*self.trial_columns, *self._minimal_schema.keys()])
+                for frame in event_pl_df_list
+            ]
+        return [
+            EventDataFrame(
+                frame,
+                trial_columns=self.trial_columns,
+            ) for frame in event_pl_df_list
+        ]
+
     def _add_minimal_schema_columns(self, df: pl.DataFrame) -> pl.DataFrame:
         """Add minimal schema columns to :py:class:`polars.DataFrame` if they are missing.
 

--- a/src/pymovements/gaze/gaze_dataframe.py
+++ b/src/pymovements/gaze/gaze_dataframe.py
@@ -296,15 +296,22 @@ class GazeDataFrame:
             A list of new GazeDataFrame instances, each containing a partition of the
             original data with all metadata and configurations preserved.
         """
+        frames = self.frame.partition_by(by=by)
+        # we cannot directly zip because we need to check if by is in events columns
+        events_list = self.events.split(by) if by in self.events.columns else [
+            pm.EventDataFrame(),
+        ] * len(frames)
+
         return [
             GazeDataFrame(
-                new_frame,
+                frame,
                 experiment=self.experiment,
                 trial_columns=self.trial_columns,
                 time_column='time',
                 distance_column='distance',
+                events=events,
             )
-            for new_frame in self.frame.partition_by(by=by)
+            for frame, events in zip(frames, events_list)
         ]
 
     def transform(

--- a/tests/unit/events/frame_test.py
+++ b/tests/unit/events/frame_test.py
@@ -486,3 +486,46 @@ def test_event_dataframe_add_trial_column_raises_exception(events, kwargs, excep
         events.add_trial_column(**kwargs)
 
     assert message == excinfo.value.args[0]
+
+
+def test_eventdataframe_split():
+    event_df = pm.EventDataFrame(
+        pl.DataFrame(
+            {
+                'trial_id': [0, 1, 1, 2],
+                'name': ['fixation', 'fixation', 'fixation', 'fixation'],
+                'onset': [0, 1, 2, 3],
+                'offset': [1, 2, 44, 1340],
+                'duration': [1, 1, 42, 1337],
+            },
+        ),
+    )
+
+    split_event = event_df.split('trial_id')
+    assert all(event_df.frame.n_unique('trial_id') == 1 for event_df in split_event)
+    assert len(split_event) == 3
+    assert_frame_equal(event_df.frame.filter(pl.col('trial_id') == 0), split_event[0].frame)
+    assert_frame_equal(event_df.frame.filter(pl.col('trial_id') == 1), split_event[1].frame)
+    assert_frame_equal(event_df.frame.filter(pl.col('trial_id') == 2), split_event[2].frame)
+
+
+def test_eventdataframe_split_trial_columns():
+    event_df = pm.EventDataFrame(
+        pl.DataFrame(
+            {
+                'trial_id': [0, 1, 1, 2],
+                'name': ['fixation', 'fixation', 'fixation', 'fixation'],
+                'onset': [0, 1, 2, 3],
+                'offset': [1, 2, 44, 1340],
+                'duration': [1, 1, 42, 1337],
+            },
+        ),
+        trial_columns='trial_id',
+    )
+
+    split_event = event_df.split('trial_id')
+    assert all(event_df.frame.n_unique('trial_id') == 1 for event_df in split_event)
+    assert len(split_event) == 3
+    assert_frame_equal(event_df.frame.filter(pl.col('trial_id') == 0), split_event[0].frame)
+    assert_frame_equal(event_df.frame.filter(pl.col('trial_id') == 1), split_event[1].frame)
+    assert_frame_equal(event_df.frame.filter(pl.col('trial_id') == 2), split_event[2].frame)


### PR DESCRIPTION
resolves #1126


to reproduce run the script `s.py`:

```python
import pymovements as pm

# get single csv file with multiple trials
pm.Dataset('JuDo1000', 'data').download()

# get experiment for event extraction
ddef = pm.DatasetLibrary.get('JuDo1000')

# load file from csv
gaze = pm.gaze.from_csv(
    './data/raw/JuDo1000/110_1.csv',
    separator='\t',
    trial_columns='trialId',
    pixel_columns=['x_left', 'x_right', 'y_left', 'y_right'],
    experiment=ddef.experiment,
)
gaze.pix2deg()
gaze.pos2vel()

# detect events
gaze.detect('idt')
split_gaze = gaze.split('trialId')
print(split_gaze[0].events)
```

which produces

```console
(venv) siqube@c-cube:~/lab/aeye-lab/pymovements
$ python s.py 
shape: (6, 5)
┌─────────┬──────────┬──────────┬──────────┬──────────┐
│ trialId ┆ name     ┆ onset    ┆ offset   ┆ duration │
│ ---     ┆ ---      ┆ ---      ┆ ---      ┆ ---      │
│ i64     ┆ str      ┆ i64      ┆ i64      ┆ i64      │
╞═════════╪══════════╪══════════╪══════════╪══════════╡
│ 1       ┆ fixation ┆ 22052506 ┆ 22052668 ┆ 162      │
│ 1       ┆ fixation ┆ 22052720 ┆ 22053659 ┆ 939      │
│ 1       ┆ fixation ┆ 22053719 ┆ 22053888 ┆ 169      │
│ 1       ┆ fixation ┆ 22053908 ┆ 22054272 ┆ 364      │
│ 1       ┆ fixation ┆ 22054301 ┆ 22056699 ┆ 2398     │
│ 1       ┆ fixation ┆ 22056755 ┆ 22057533 ┆ 778      │
└─────────┴──────────┴──────────┴──────────┴──────────┘
```