### PR TITLE
chore!: restrict boolean arguments in `to_dict()` to keyword-only

### DIFF
--- a/src/pymovements/dataset/dataset_definition.py
+++ b/src/pymovements/dataset/dataset_definition.py
@@ -201,7 +201,12 @@ class DatasetDefinition:
         # Initialize DatasetDefinition with YAML data
         return DatasetDefinition(**data)
 
-    def to_dict(self, exclude_private: bool = True, exclude_none: bool = True) -> dict[str, Any]:
+    def to_dict(
+        self,
+        *,
+        exclude_private: bool = True,
+        exclude_none: bool = True,
+    ) -> dict[str, Any]:
         """Return dictionary representation.
 
         Parameters
@@ -242,7 +247,9 @@ class DatasetDefinition:
         return data
 
     def to_yaml(
-        self, path: str | Path,
+        self,
+        path: str | Path,
+        *,
         exclude_private: bool = True,
         exclude_none: bool = True,
     ) -> None:

--- a/src/pymovements/gaze/experiment.py
+++ b/src/pymovements/gaze/experiment.py
@@ -282,7 +282,7 @@ class Experiment:
         return self.screen == other.screen and self.eyetracker == other.eyetracker
 
     def to_dict(
-        self, exclude_none: bool = True,
+        self, *, exclude_none: bool = True,
     ) -> dict[str, Any | dict[str, str | float | None]]:
         """Convert the experiment instance into a dictionary.
 

--- a/src/pymovements/gaze/eyetracker.py
+++ b/src/pymovements/gaze/eyetracker.py
@@ -80,7 +80,7 @@ class EyeTracker:
         if self.sampling_rate is not None:
             _checks.check_is_greater_than_zero(sampling_rate=self.sampling_rate)
 
-    def to_dict(self, exclude_none: bool = True) -> dict[str, Any]:
+    def to_dict(self, *, exclude_none: bool = True) -> dict[str, Any]:
         """Convert the EyeTracker instance into a dictionary.
 
         Parameters

--- a/src/pymovements/gaze/screen.py
+++ b/src/pymovements/gaze/screen.py
@@ -285,7 +285,7 @@ class Screen:
         assert isinstance(value, (int, float))
         _checks.check_is_greater_than_zero(**{key: value})
 
-    def to_dict(self, exclude_none: bool = True) -> dict[str, Any]:
+    def to_dict(self, *, exclude_none: bool = True) -> dict[str, Any]:
         """Convert the Screen instance into a dictionary.
 
         Parameters


### PR DESCRIPTION
## Description

Allowing the two boolean arguments to be passed as positional arguments is error-prone for switchups and can lead to problems with future enhancements and backwards compatiblity. The arguments should be restricted to keyword only until we have a stable interface.

