### PR TITLE
fix: don't share experiment instance between loaded files

### DIFF
--- a/src/pymovements/dataset/dataset_files.py
+++ b/src/pymovements/dataset/dataset_files.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import warnings
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -257,7 +258,7 @@ def load_gaze_files(
         gaze_df = load_gaze_file(
             filepath=filepath,
             fileinfo_row=fileinfo_row,
-            definition=definition,
+            definition=deepcopy(definition),
             preprocessed=preprocessed,
         )
         gaze_dfs.append(gaze_df)

--- a/tests/unit/dataset/dataset_test.py
+++ b/tests/unit/dataset/dataset_test.py
@@ -528,7 +528,6 @@ def test_loaded_gazes_do_not_share_experiment_with_definition(gaze_dataset_confi
     definition = gaze_dataset_configuration['init_kwargs']['definition']
 
     for result_gaze in dataset.gaze:
-        assert False, (result_gaze.experiment, definition.experiment)
         assert result_gaze.experiment is not definition.experiment
 
 

--- a/tests/unit/dataset/dataset_test.py
+++ b/tests/unit/dataset/dataset_test.py
@@ -527,20 +527,20 @@ def test_loaded_gazes_do_not_share_experiment_with_definition(gaze_dataset_confi
 
     definition = gaze_dataset_configuration['init_kwargs']['definition']
 
-    for result_gaze in dataset.gaze:
-        assert result_gaze.experiment is not definition.experiment
+    for gaze in dataset.gaze:
+        assert gaze.experiment is not definition.experiment
 
 
 def test_loaded_gazes_do_not_share_experiment_with_other(gaze_dataset_configuration):
     dataset = Dataset(**gaze_dataset_configuration['init_kwargs'])
     dataset.load()
 
-    for result_gaze1 in dataset.gaze:
-        for result_gaze2 in dataset.gaze:
-            if result_gaze1 == result_gaze2:
+    for gaze1 in dataset.gaze:
+        for gaze2 in dataset.gaze:
+            if gaze1 is gaze2:
                 continue
 
-            assert result_gaze1.experiment is not result_gaze2.experiment
+            assert gaze1.experiment is not gaze2.experiment
 
 
 def test_load_gaze_has_position_columns(gaze_dataset_configuration):

--- a/tests/unit/dataset/dataset_test.py
+++ b/tests/unit/dataset/dataset_test.py
@@ -521,6 +521,29 @@ def test_load_correct_raw_gaze_dfs(gaze_dataset_configuration):
         )
 
 
+def test_loaded_gazes_do_not_share_experiment_with_definition(gaze_dataset_configuration):
+    dataset = Dataset(**gaze_dataset_configuration['init_kwargs'])
+    dataset.load()
+
+    definition = gaze_dataset_configuration['init_kwargs']['definition']
+
+    for result_gaze in dataset.gaze:
+        assert False, (result_gaze.experiment, definition.experiment)
+        assert result_gaze.experiment is not definition.experiment
+
+
+def test_loaded_gazes_do_not_share_experiment_with_other(gaze_dataset_configuration):
+    dataset = Dataset(**gaze_dataset_configuration['init_kwargs'])
+    dataset.load()
+
+    for result_gaze1 in dataset.gaze:
+        for result_gaze2 in dataset.gaze:
+            if result_gaze1 == result_gaze2:
+                continue
+
+            assert result_gaze1.experiment is not result_gaze2.experiment
+
+
 def test_load_gaze_has_position_columns(gaze_dataset_configuration):
     dataset = Dataset(**gaze_dataset_configuration['init_kwargs'])
     dataset.load(preprocessed=True)


### PR DESCRIPTION
## Description

#1102 has exposed a bug where loaded gaze files share the same experiment instance. 

## Implemented changes

- [x] deepcopy definition before passing it to loader functions

## How Has This Been Tested?

- [x] test that experiment is not the same instance as in definition
- [x] test that experiments are not shared between loaded files

## Type of change

- Bug fix

## Context

#### required by:
- #1102

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
