### PR TITLE
docs: Change `five_point` to `fivepoint`

### DIFF
--- a/src/pymovements/gaze/transforms.py
+++ b/src/pymovements/gaze/transforms.py
@@ -531,7 +531,7 @@ def pos2vel(
 
     * ``savitzky_golay``: velocity is calculated by a polynomial of fixed degree and window length.
       See :py:func:`~pymovements.gaze.transforms.savitzky_golay` for further details.
-    * ``five_point``: velocity is calculated from the difference of the mean values
+    * ``fivepoint``: velocity is calculated from the difference of the mean values
       of the subsequent two samples and the preceding two samples
     * ``neighbors``: velocity is calculated from difference of the subsequent
       sample and the preceding sample

--- a/tests/unit/gaze/gaze_transform_test.py
+++ b/tests/unit/gaze/gaze_transform_test.py
@@ -672,7 +672,7 @@ def fixture_experiment():
                 position_columns=['x_dva', 'y_dva'],
                 velocity_columns=['x_vel', 'y_vel'],
             ),
-            id='pos2vel_five_point',
+            id='pos2vel_fivepoint',
         ),
 
         pytest.param(


### PR DESCRIPTION
The docstring listed `"five_point"` as a valid method in `pos2vel()`, but the only accepted spelling for that method is `"fivepoint"`: https://github.com/aeye-lab/pymovements/blob/f093a0b61083747b80ffdcade378aefe169f726e/src/pymovements/gaze/transforms.py#L595