### PR TITLE
ci: ignore pybtex pkg_resources UserWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
   "nbconvert>=7.0.0,<7.17",
   "nbsphinx>=0.8.8,<0.10",
   "pandoc",
-  "pybtex",
+  "pybtex<0.24.1",
   "pydata-sphinx-theme>=0.12",
   "setuptools>=61.0.0,<81",
   "sphinx>=7.0,<8.3",
@@ -65,7 +65,6 @@ docs = [
   "sphinxcontrib.bibtex>=2.4.1"
 ]
 test = [
-  "pybtex",
   "pytest>=6.0.0",
   "pytest-benchmark>=5.1.0",
   "pytest-cov>=4.0.0",


### PR DESCRIPTION
starting from `80.9.0` setuptools now emits an additional `UserWarning` on import, as it will be completely removed in november. the issue is already fixed in `pybtex` but a new release is still missing. dependabot will notify us on a new pybtex release. then we can finally remove these warning filters.