### PR TITLE
docs: update discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and render plots to visually analyze your results.
 - **Bug reports:** https://github.com/aeye-lab/pymovements/issues
 - **Contributing:** https://github.com/aeye-lab/pymovements/blob/main/CONTRIBUTING.md
 - **Mailing list:** pymovements@python.org ([subscribe](https://mail.python.org/mailman3/lists/pymovements.python.org/))
-- **Discord:** https://discord.gg/Z7VMSbDm
+- **Discord:** https://discord.gg/K2uS2R6PNj
 
 
 ## Getting Started


### PR DESCRIPTION
old link was expired. this link is set to never expire. Here's the new link: https://discord.gg/K2uS2R6PNj

resolves #1166