### PR TITLE
docs: Fix number of subjects in UCL dataset

### DIFF
--- a/docs/source/datasets/public_datasets.csv
+++ b/docs/source/datasets/public_datasets.csv
@@ -22,4 +22,4 @@ Dataset,Citation,Samples,Events,Reading Measures,# Subjects,# Sessions per Subje
 :py:class:`~pymovements.datasets.PotsdamBingeWearablePVT`,:cite:p:`PotsdamBingePVT`,X,,,57,2,200 Hz (upsampled to 1000 Hz),Dots (PVT test)
 :py:class:`~pymovements.datasets.Provo`,:cite:p:`Provo`,,X,,470,1,1000 Hz,Text (documents)
 :py:class:`~pymovements.datasets.SBSAT`,:cite:p:`SB-SAT`,X,X,,95,1,1000 Hz,Text (documents)
-:py:class:`~pymovements.datasets.UCL`,:cite:p:`UCL`,,X,X,117,1,500 Hz,Text (sentences)
+:py:class:`~pymovements.datasets.UCL`,:cite:p:`UCL`,,X,X,43,1,500 Hz,Text (sentences)


### PR DESCRIPTION
(Fixing my mistake from #1040)

Only 43 subjects took part in the eye tracking part of the dataset (see [here](https://link.springer.com/article/10.3758/s13428-012-0313-y#Sec7); the 117 is for self-paced reading).