### PR TITLE
feat: Add HTML representation for ResourceDefinition

### DIFF
--- a/src/pymovements/dataset/resources.py
+++ b/src/pymovements/dataset/resources.py
@@ -30,7 +30,10 @@ from warnings import warn
 
 from deprecated.sphinx import deprecated
 
+from pymovements._utils._html import repr_html
 
+
+@repr_html()
 @dataclass
 class ResourceDefinition:
     """ResourceDefinition definition.


### PR DESCRIPTION
`ResourceDefinition` didn't have a nice HTML representation for notebooks.