### PR TITLE
docs: update from_asc to include information about the edf2asc tool

### DIFF
--- a/src/pymovements/gaze/io.py
+++ b/src/pymovements/gaze/io.py
@@ -308,7 +308,7 @@ def from_asc(
     Parameters
     ----------
     file: str | Path
-        Path of IPC/feather file.
+        Path of ASC file.
     patterns: str | list[dict[str, Any] | str] | None
         List of patterns to match for additional columns or a key identifier of eye tracker specific
         default patterns. Supported values are: `'eyelink'`. If `None` is passed, `'eyelink'` is
@@ -346,8 +346,13 @@ def from_asc(
 
     Examples
     --------
-    Let's assume we have an EyeLink asc file stored at `tests/files/eyelink_monocular_example.asc`.
-    We can then load the data into a ``Gaze``:
+    ASC files are created from EyeLink EDF files using the edf2asc tool. The ASC file contains gaze samples, events, and metadata about the experiment.
+    This function assumes that the ASC file is in the default format created by edf2asc.
+    For example, if you have an Eyelink EDF file stored at `tests/files/eyelink_monocular_example.edf`, you can convert it to an ASC file using the following command (requires the edf2asc tool which can be downloaded from the SR Research Support website):
+    ```
+    edf2asc tests/files/eyelink_monocular_example.edf tests/files/eyelink_monocular_example.asc
+    ```
+    We can then load the asc file stored at `tests/files/eyelink_monocular_example.asc` into a ``Gaze``:
 
     >>> from pymovements.gaze.io import from_asc
     >>> gaze = from_asc(file='tests/files/eyelink_monocular_example.asc')


### PR DESCRIPTION
### Description
This pull request enhances the documentation for the `from_asc` function in the `pymovements.gaze.io` module. 

### Changes Made
 - Included a detailed example in the docstring to demonstrate how to convert an EyeLink EDF file to an ASC file using the `edf2asc` tool.
 - Expanded the example, showing how the asc file can be created from an EDF file using edf2asc
