### PR TITLE
Docs: Remove `tqdm` warnings from notebooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 docs = [
-  "ipykernel>=6.13.0",
-  "ipywidgets>=8.1.7",
+  "ipykernel>=6.13.0,<6.31",
+  "ipywidgets>=8.1.7,<8.2",
   "nbconvert>=7.0.0,<7.17",
   "nbsphinx>=0.8.8,<0.10",
   "pandoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 docs = [
   "ipykernel>=6.13.0",
+  "ipywidgets>=8.1.7",
   "nbconvert>=7.0.0,<7.17",
   "nbsphinx>=0.8.8,<0.10",
   "pandoc",


### PR DESCRIPTION
## Description

Notebooks in tutorials show warning when importing `pymovements`.

<img width="1860" height="1300" alt="image" src="https://github.com/user-attachments/assets/7b8a6abb-6ec0-4370-9084-1473f44863de" />

When building the sphinx pages locally I encountered this warning, but noticed it is also produced by production/readthedocs.
This warning is raised in every norebook in the tutorial section, in the `stable` and `latest` docs: https://pymovements.readthedocs.io/en/latest/tutorials/local-dataset.html

Looking it up I have found https://github.com/microsoft/vscode-jupyter/issues/12684, describing that `ipywidgets` are not included in the umbrella `jupyter` package.

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] Add `ipywidgets` to `docs` dependencies

## How Has This Been Tested?

- [x] Build doc pages locally

<img width="1888" height="1138" alt="image" src="https://github.com/user-attachments/assets/d1d0698c-6114-4f3e-ab32-beeff14a5bda" />

- Warning is removed
- `ipywidgets` shows second loading bar in pretty

## Type of change

Remove irrelevant items:
- Bug fix
- Documentation update

## Context

Solution is up to discussion.

Relates to https://github.com/aeye-lab/pymovements/issues/1210

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
