### PR TITLE
docs: quote pip extras so command works in zsh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,10 +134,10 @@ We use [`flake8`](https://pypi.org/project/flake8/) for quick style checks and
 https://pypi.org/project/mypy/) for checking type annotations.
 
 You can check your code style by using [pre-commit](https://www.pre-commit.com).
-You can install `pre-commit` and `pylint` via pip:
+You can install `pre-commit` and `pylint` via pip. **Note**: Quoting '[dev]' ensures the command works in both bash and zsh.
 
 ```bash
-pip install -e .[dev]
+pip install -e '.[dev]'
 ```
 
 To always run style checks when pushing commits upstream,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,9 @@ We use [`flake8`](https://pypi.org/project/flake8/) for quick style checks and
 https://pypi.org/project/mypy/) for checking type annotations.
 
 You can check your code style by using [pre-commit](https://www.pre-commit.com).
-You can install `pre-commit` and `pylint` via pip. **Note**: Quoting '.[dev,docs,test]' ensures the command works in both bash and zsh.
+You can install `pre-commit` and `pylint` via pip.
+
+**Note**: Quoting '.[dev]' ensures the command works in both bash and zsh.
 
 ```bash
 pip install -e '.[dev]'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ We use [`flake8`](https://pypi.org/project/flake8/) for quick style checks and
 https://pypi.org/project/mypy/) for checking type annotations.
 
 You can check your code style by using [pre-commit](https://www.pre-commit.com).
-You can install `pre-commit` and `pylint` via pip. **Note**: Quoting '[dev]' ensures the command works in both bash and zsh.
+You can install `pre-commit` and `pylint` via pip. **Note**: Quoting '.[dev,docs,test]' ensures the command works in both bash and zsh.
 
 ```bash
 pip install -e '.[dev]'
@@ -188,7 +188,7 @@ in a separate environment using [Tox](https://tox.readthedocs.io/en/latest/).
 If you have not yet installed `tox` and the testing dependencies you can do so via
 
 ```bash
-pip install -e .[dev]
+pip install -e '.[dev]'
 ```
 
 You can run all tests on all supported python versions run by simply calling `tox` in the repository root.
@@ -219,7 +219,7 @@ documentation as an example.
 To generate documentation pages, you can install the necessary dependencies using:
 
 ```bash
-pip install -e .[docs]
+pip install -e '.[docs]'
 ```
 
 [Sphinx](https://www.sphinx-doc.org) generates the API documentation from the


### PR DESCRIPTION
## Description

This PR updates the installation instructions for development dependencies.
On zsh, the command `pip install -e .[dev]` fails with `zsh: no matches found: .[dev]` because zsh interprets [dev] as a glob pattern. This change updates the docs to use `pip install -e '.[dev,docs]'` which works in both bash and zsh.
A short note is added to explain the quoting.

## Implemented changes

- [x] Updated installation snippet in CONTRIBUTING.md to use pip install -e '.[dev,docs]'
- [x] Added note explaining why quoting is required for zsh

## How Has This Been Tested?

- [x] Verified that the new command installs dependencies correctly in zsh
- [x] Verified that the same command still works in bash

## Type of change

- Documentation update

## Context

Resolves N/A (docs fix, no open issue linked)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
