### PR TITLE
docs: corrected and expanded the descriptions for BSC and BSCII

### DIFF
--- a/src/pymovements/datasets/bsc.py
+++ b/src/pymovements/datasets/bsc.py
@@ -32,11 +32,10 @@ from pymovements.dataset.resources import ResourceDefinitions
 class BSC(DatasetDefinition):
     """BSC dataset :cite:p:`BSC`.
 
-    This dataset includes monocular eye tracking data from a single participant in a single
-    session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
-    eye tracker and precomputed events on aoi level are reported.
-
-    The participant is instructed to read texts and answer questions.
+    The Beijing Sentence Corpus (BSC) is a Simplified Chinese sentence corpus of eye-tracking data,
+    including word boundaries and predictability norms for each word. The sentences were selected
+    from the People's Daily, the largest newspaper group and an official newspaper of the People's
+    Republic of China. Data was collected from 60 native Chinese university students.
 
     Check the respective paper for details :cite:p:`BSC`.
 

--- a/src/pymovements/datasets/bsc.py
+++ b/src/pymovements/datasets/bsc.py
@@ -35,7 +35,8 @@ class BSC(DatasetDefinition):
     The Beijing Sentence Corpus (BSC) is a Simplified Chinese sentence corpus of eye-tracking data,
     including word boundaries and predictability norms for each word. The sentences were selected
     from the People's Daily, the largest newspaper group and an official newspaper of the People's
-    Republic of China. Data was collected from 60 native Chinese university students.
+    Republic of China. Data was collected from 60 native Chinese university students. The eye
+    movements were recorded with an Eyelink II system running at 500 Hz.
 
     Check the respective paper for details :cite:p:`BSC`.
 

--- a/src/pymovements/datasets/bsc2.py
+++ b/src/pymovements/datasets/bsc2.py
@@ -36,11 +36,11 @@ class BSCII(DatasetDefinition):
     data, based on the original Beijing Sentence Corpus (BSC) in Simplified Chinese. Data was
     collected from 60 native Traditional Chinese readers. The corpus enables analyses of word
     frequency, visual complexity, and predictability on fixation location and duration.
-    
+
     Since the BSCII sentences are nearly identical to those in the BSC, the two corpora together
     provide a valuable resource for studying cross-script similarities and differences between
     Simplified and Traditional Chinese.
-    
+
     Eye-movements were recorded with an Eyelink 1000 system at 1000 Hz.
 
     Check the respective paper for details :cite:p:`BSCII`.

--- a/src/pymovements/datasets/bsc2.py
+++ b/src/pymovements/datasets/bsc2.py
@@ -32,12 +32,12 @@ from pymovements.dataset.resources import ResourceDefinitions
 class BSCII(DatasetDefinition):
     """BSCII dataset :cite:p:`BSCII`.
 
-    This dataset includes monocular eye tracking data from a single participant in a single
-    session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000
-    eye tracker and precomputed events on aoi level are reported.
-
-    The participant is instructed to read texts and answer questions. The original purpose was to
-    look into the differences in processing when reading simplified and traditional Chinese.
+    The Beijing Sentence Corpus II (BSCII) is a Traditional Chinese sentence corpus of eye-tracking
+    data, based on the original BSC in Simplified Chinese. Data was collected from 60
+    native TC readers. The corpus enables analyses of word frequency, visual complexity, and
+    predictability on fixation location and duration. Since the BSCII sentences are nearly
+    identical to those in the BSC, the two corpora together provide a valuable resource for
+    studying cross-script similarities and differences between Simplified and Traditional Chinese.
 
     Check the respective paper for details :cite:p:`BSCII`.
 

--- a/src/pymovements/datasets/bsc2.py
+++ b/src/pymovements/datasets/bsc2.py
@@ -33,12 +33,15 @@ class BSCII(DatasetDefinition):
     """BSCII dataset :cite:p:`BSCII`.
 
     The Beijing Sentence Corpus II (BSCII) is a Traditional Chinese sentence corpus of eye-tracking
-    data, based on the original BSC in Simplified Chinese. Data was collected from 60
-    native TC readers. The corpus enables analyses of word frequency, visual complexity, and
-    predictability on fixation location and duration. Since the BSCII sentences are nearly
-    identical to those in the BSC, the two corpora together provide a valuable resource for
-    studying cross-script similarities and differences between Simplified and Traditional Chinese.
-    The eye-movements were recorded with an Eyelink 1000 system at 1000 Hz.
+    data, based on the original Beijing Sentence Corpus (BSC) in Simplified Chinese. Data was
+    collected from 60 native Traditional Chinese readers. The corpus enables analyses of word
+    frequency, visual complexity, and predictability on fixation location and duration.
+    
+    Since the BSCII sentences are nearly identical to those in the BSC, the two corpora together
+    provide a valuable resource for studying cross-script similarities and differences between
+    Simplified and Traditional Chinese.
+    
+    Eye-movements were recorded with an Eyelink 1000 system at 1000 Hz.
 
     Check the respective paper for details :cite:p:`BSCII`.
 

--- a/src/pymovements/datasets/bsc2.py
+++ b/src/pymovements/datasets/bsc2.py
@@ -38,6 +38,7 @@ class BSCII(DatasetDefinition):
     predictability on fixation location and duration. Since the BSCII sentences are nearly
     identical to those in the BSC, the two corpora together provide a valuable resource for
     studying cross-script similarities and differences between Simplified and Traditional Chinese.
+    The eye-movements were recorded with an Eyelink 1000 system at 1000 Hz.
 
     Check the respective paper for details :cite:p:`BSCII`.
 


### PR DESCRIPTION
## Description

The descriptions of the BCS and BSCII corpora were faulty and possibly copy-pasted from some other corpus (most probably from the toy dataset). Both descriptions identically claimed: "This dataset includes monocular eye tracking data from a single participant in a single session. Eye movements are recorded at a sampling frequency of 1,000 Hz using an EyeLink 1000 eye tracker and precomputed events on aoi level are reported." 

However, the reference papers [[Pan et al., 2022](https://pymovements.readthedocs.io/en/stable/bibliography.html#id2), [Yan et al., 2025](https://pymovements.readthedocs.io/en/stable/bibliography.html#id3)]  and the data itself indicate there are 60 participants and various sampling frequencies.  

## Implemented changes

- [x] Fixed and expanded the description of BSC, including adding the info that it is Simplified Chinese.
- [x] Fixed and expanded the description of BSCII, also mentioning that it is Traditional Chinese.

## How Has This Been Tested?

No tests were performed but i consulted the publications and Deborah :)

## Type of change

Remove irrelevant items:
- Documentation update