### PR TITLE
feat: add equality comparison methods for `Events` and `Gaze`

### DIFF
--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -522,6 +522,12 @@ class Events:
         aoi_df = pl.concat(aois)
         self.frame = pl.concat([self.frame, aoi_df], how='horizontal')
 
+    def __eq__(self, other: Events) -> bool:
+        """Check equality between this and another :py:cls:`~pymovements.events.Events` object."""
+        frames_equal = self.frame.equals(other.frame)
+        trial_columns_equal = self.trial_columns == other.trial_columns
+        return frames_equal and trial_columns_equal
+
     def __str__(self: Any) -> str:
         """Return string representation of event dataframe."""
         return self.frame.__str__()

--- a/tests/unit/events/events_test.py
+++ b/tests/unit/events/events_test.py
@@ -423,6 +423,77 @@ def test_init_expected_trial_column_data(kwargs, expected_trial_column_data):
     assert_frame_equal(events.frame[events.trial_columns], expected_trial_column_data)
 
 
+@pytest.mark.parametrize(
+    ('events_left', 'events_right', 'expected_equality'),
+    [
+        pytest.param(
+            Events(),
+            Events(),
+            True,
+            id='empty_events',
+        ),
+        pytest.param(
+            Events(),
+            Events(onsets=[0], offsets=[1]),
+            False,
+            id='one_empty_one_not',
+        ),
+        pytest.param(
+            Events(
+                pl.from_dict({'name': ['saccade'], 'onset': [0], 'offset': [1]}),
+            ),
+            Events(name=['saccade'], onsets=[0], offsets=[1]),
+            True,
+            id='same_events',
+        ),
+        pytest.param(
+            Events(
+                pl.from_dict({'name': ['saccade', None], 'onset': [0, 1], 'offset': [1, 2]}),
+            ),
+            Events(
+                pl.from_dict({'name': ['saccade', None], 'onset': [0, 1], 'offset': [1, 2]}),
+            ),
+            True,
+            id='same_events_with_nulls',
+        ),
+        pytest.param(
+            Events(name=['saccade'], onsets=[0], offsets=[1]),
+            Events(name=['fixation'], onsets=[0], offsets=[1]),
+            False,
+            id='different_events',
+        ),
+        pytest.param(
+            Events(name=['saccade'], onsets=[0], offsets=[1], trials=[0]),
+            Events(name=['saccade'], onsets=[0], offsets=[1], trials=[1]),
+            False,
+            id='same_events_different_trials',
+        ),
+        pytest.param(
+            Events(
+                pl.from_dict({'trial': [0], 'name': ['saccade'], 'onset': [0], 'offset': [1]}),
+                trial_columns='trial',
+            ),
+            Events(name=['saccade'], onsets=[0], offsets=[1], trials=[0]),
+            True,
+            id='same_events_same_trials',
+        ),
+        pytest.param(
+            Events(
+                pl.from_dict({'trial': [0], 'name': ['saccade'], 'onset': [0], 'offset': [1]}),
+                trial_columns='trial',
+            ),
+            Events(
+                pl.from_dict({'trial': [0], 'name': ['saccade'], 'onset': [0], 'offset': [1]}),
+            ),
+            False,
+            id='same_events_same_trials_different_trial_columns',
+        ),
+    ],
+)
+def test_equality(events_left, events_right, expected_equality):
+    assert (events_left == events_right) == expected_equality
+
+
 def test_columns_same_as_frame():
     init_kwargs = {'onsets': [0], 'offsets': [1]}
     events = Events(**init_kwargs)


### PR DESCRIPTION
## Description

Implement equality comparison methods for `Events` and `Gaze`.

## Implemented changes

- [ ] implement `Events.__eq__()`
- [ ] implement `Gaze.__eq__()`

## How Has This Been Tested?

- [ ] added parametrized test function to `events_test.py`
- [ ] added parametrized test function to `gaze_test.py`
