### PR TITLE
ci: exclude pre-commit-ci bot in release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,8 +32,7 @@ exclude-labels:
   - skip changelog
 
 exclude-contributors:
-  - dependabot[bot]
-  - pre-commit-ci[bot]
+  - pre-commit-ci
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'


### PR DESCRIPTION
## Description

I don't understand why, but the bots are never excluded in the release draft.
I removed the trailing `[bot]` and reverted the `dependabot` exclude, as updating package dependencies is useful information in the changelog.
