### PR TITLE
ci: revert removing exclude of bot contributors

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,7 +32,9 @@ exclude-labels:
   - skip changelog
 
 exclude-contributors:
+  - dependabot[bot]
   - pre-commit-ci
+  - pre-commit-ci[bot]
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'


### PR DESCRIPTION
## Description

ignoring the author `pre-commit-ci` in #1306 seems to work, but the contributors with the `[bot]` suffix are still needed to be ignored.

The current release draft now contains the following bots: `@dependabot, @dependabot[bot], @pre-commit-ci[bot]`

Before merging #1306 it was: `@dependabot, @pre-commit-ci`

After merging this PR it should only contain `@dependabot`