### PR TITLE
fix: correct broken CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 
+title: "pymovements: A Python Package for Processing Eye Movement Data"
+
 authors:
   - family-names: "Krakowczyk"
     given-names: "Daniel G."
@@ -62,8 +64,6 @@ authors:
   - family-names: "Jäger"
     given-names: "Lena A."
     orcid: "https://orcid.org/0000-0001-9018-9713"
-
-title: "pymovements: A Python Package for Processing Eye Movement Data"
 
 type: software
 license: MIT


### PR DESCRIPTION
## Description

The current CITATION.cff file is not compatible with zenodo and leads to the following error on sync:

```
{
    "error_id": "30e73c398a81471bab0c442aa17f88ca",
    "errors": "Citation metadata load failed"
}
```

This PR aims to fix the errors in the file such that zenodo autosyncs when creating a new release.

## Implemented changes

- [x] remove invalid fields from preferred citation (collection-location, collection-series)
- [x] add missing fields (license, type: software)
- [x] add orcids to authors

