### PR TITLE
test: close plots in deprecated plotting tests

### DIFF
--- a/tests/unit/utils/plotting_test.py
+++ b/tests/unit/utils/plotting_test.py
@@ -20,7 +20,7 @@
 """Test pymovements plotting utils."""
 import re
 
-import matplotlib.pyplot
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -38,7 +38,7 @@ from pymovements.utils.plotting import setup_matplotlib
     ],
 )
 def axes_fixture(request):
-    fig = matplotlib.pyplot.figure(figsize=request.param)
+    fig = plt.figure(figsize=request.param)
     yield fig.gca()
 
 
@@ -58,17 +58,20 @@ def axes_fixture(request):
 )
 def test_setup_matplotlib(kwargs):
     setup_matplotlib(**kwargs)
+    plt.close()
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_draw_image_stimulus(axes, make_example_file):
     filepath = make_example_file('pexels-zoorg-1000498.jpg')
     draw_image_stimulus(image_stimulus=filepath, ax=axes)
+    plt.close()
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_draw_line_data(axes):
     draw_line_data(x_signal=np.array([0.0, 0.0]), y_signal=np.array([0.0, 0.0]), ax=axes)
+    plt.close()
 
 
 @pytest.mark.parametrize(
@@ -100,6 +103,7 @@ def test_draw_line_data(axes):
 def test_plotting_function_deprecated(plotting_function, kwargs):
     with pytest.raises(DeprecationWarning):
         plotting_function(**kwargs)
+    plt.close()
 
 
 @pytest.mark.parametrize(
@@ -131,6 +135,7 @@ def test_plotting_function_deprecated(plotting_function, kwargs):
 def test_plotting_function_removed(plotting_function, kwargs):
     with pytest.raises(DeprecationWarning) as info:
         plotting_function(**kwargs)
+    plt.close()
 
     regex = re.compile(r'.*will be removed in v(?P<version>[0-9]*[.][0-9]*[.][0-9]*)[.)].*')
 


### PR DESCRIPTION
## Description

The change in #1309 didn't affect the tests of the deprecated plotting functions in the deprecated utils submodule.

Probably these tests were responsible for the too-many-open-plots warnings.

As the whole `utils` module will be removed soon I just added `plt.close()` calls at the end of each test function.

The `conftest.py` from #1309 cannot be reused here as it's in a different directory.

## Implemented changes

- [x] added `plt.close()` to all tests in `tests/unit/utils/plotting_test.py`

## Context

#### related issues:
- #1309
- #1330


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
