### PR TITLE
docs: remove message note from CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,4 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
 
 title: "pymovements: A Python Package for Processing Eye Movement Data"
 


### PR DESCRIPTION
The message is not displayed by GitHub and on zenodo this just looks strange:

<img width="2968" height="1350" alt="image" src="https://github.com/user-attachments/assets/3d0d961a-db8a-4fc4-aca4-48a94ac19f62" />
