### PR TITLE
ci: raise minimum versions for some dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,9 @@ dev = [
   "pytest-benchmark>=5.1.0",
   "pytest-cov>=4.0.0",
   "setuptools>=61.0.0",
-  "types-tqdm>=4.64.0",
+  "types-tqdm>=4.67.0",
   "pre-commit>=3.0.0",
-  "pylint>=3.0.0"
+  "pylint>=4.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

@cbueth reported that this error still persisted:

```
pylint...................................................................Failed
- hook id: pylint
- exit code: 2

************* Module pymovements.dataset._utils._downloads
src/pymovements/dataset/_utils/_downloads.py:151: [E0240(inconsistent-mro), _DownloadProgressBar] Inconsistent method resolution order for class '_DownloadProgressBar'
```

Updating some of the test dependencies should resolve the error.