### PR TITLE
docs: re-add colagaze warning

### DIFF
--- a/src/pymovements/datasets/colagaze.py
+++ b/src/pymovements/datasets/colagaze.py
@@ -46,7 +46,7 @@ class CoLAGaze(DatasetDefinition):
     parsing of individual files.
 
     See issue `#1401 <https://github.com/pymovements/pymovements/issues/1401>`__ for reference.
-    
+
     Attributes
     ----------
     name: str


### PR DESCRIPTION
#1351 accidentally removed the warning