### PR TITLE
build: set minimum version for pyparsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,14 @@ classifiers = [
 ]
 dependencies = [
   "deprecated>=1.2.18",
-  "matplotlib>=3.8.0",
   "fastexcel>=0.13.0",
+  "matplotlib>=3.8.0",
   "numpy>=1.22.4",
   "pandas>=2.1.4",
   "polars>=1.34.0",
   "pyarrow>=11.0.0",
   "pyopenssl>=22.0.0",
+  "pyparsing>=3.1.2",
   "pyreadr>=0.5.2",
   "pyyaml>=6.0.2",
   "scikit-learn>=1.2",


### PR DESCRIPTION
The minimum requirements test broke today as matplotlib v3.8.0 (minimum requirement) uses functions that are deprecated in pyparsing v3.3.1 (released today).

Strangely the min-req pip installer doesn't use the minimum requirements for the 2nd hand dependencies (dependencies of dependencies). So I just set this explicitly in pyproject.toml.