### PR TITLE
ci: add slack release notification job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,3 +59,16 @@ jobs:
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+  notify-slack:
+    name: Notify on Slack
+
+    if: ${{ !github.release.prerelease }}
+    needs: publish-to-pypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify on AEye workspace
+        uses: amendx/slackbot-release@1.0.1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

Notify about new release on slack channel (for now just on the AEye workspace). 

pre-releases should be excluded from notification.

## Implemented changes

- [ ] added bot to AEye slack workspace
- [ ] add notify slack job to publish workflow

## How Has This Been Tested?

I'm not sure if 

```
if: ${{ !github.release.prerelease }}
```

is correct, but I also can't really try it until the next pre-release.
