### PR TITLE
chore: preserve notebook metadata (tags + cell ids)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     rev: 1.3.10
     hooks:
       - id: databooks-meta
-        args: [ --cell-fields-keep=id, tags ]
+        args: [ "--cell-meta-keep=tags", "--cell-fields-keep=id"]
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.3
     hooks:
@@ -52,6 +52,7 @@ repos:
     rev: 0.9.0
     hooks:
       - id: nbstripout
+        args: [--keep-id ]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:


### PR DESCRIPTION
## Description

Follow-up to #1441 

PR #1441 aimed to preserve notebook cell tags but the configuration `--cell-fields-keep=id,tags` does not fully work because:

- `id` is a cell field
- `tags` are stored in cell metadata
-  `nbstripout`still stripped cell ids

## Implemented changes

- [x] `--cell-meta-keep=tags` to preserve documentation/rendering tags
- [x] `--cell-fields-keep=id` to keep nbformat cell ids
- [x] `nbstripout --keep-id` to prevent id regeneration

## How Has This Been Tested?

Tested locally by: 

- [x] adding tags to notebook cells, running the pre-commit suite on notebooks, and iterating on the configuration until `databooks-meta` no longer stripped cell metadata and `nbstripout` no longer rewrote cell ids
- [x] creating a local `Sphinx` build and inspecting the output

## Type of change

Remove irrelevant items:
- New functionality

## Context

Resolves #

#### related issues:
- #1441 

#### required by:
- #1435 

#### requires:
- [ ] #

#### conflicts with:
- #

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
