### PR TITLE
docs: fix whitespaces in data_loss defaults

### DIFF
--- a/src/pymovements/measure/samples/measures.py
+++ b/src/pymovements/measure/samples/measures.py
@@ -438,13 +438,13 @@ def data_loss(
     sampling_rate: float
         Expected sampling rate in Hz (must be > 0).
     time_column: str
-        Name of the timestamp column. (default:   'time'  )
+        Name of the timestamp column. (default: 'time')
     start_time: float | None
-        Recording start time. If ``None``, uses the group's first timestamp. (default:   None  )
+        Recording start time. If ``None``, uses the group's first timestamp. (default: ``None``)
     end_time: float | None
-        Recording end time. If ``None``, uses the group's last timestamp. (default:   None  )
+        Recording end time. If ``None``, uses the group's last timestamp. (default: ``None``)
     unit: Literal['count', 'time', 'ratio']
-        Aggregation unit for the result. (default:   'ratio'  )
+        Aggregation unit for the result. (default: ``'ratio'``)
 
     Returns
     -------


### PR DESCRIPTION
## Description

fix whitespace issues noted by @SiQube  in https://github.com/pymovements/pymovements/pull/1471#discussion_r2768647431
