### PR TITLE
chore: change new arrow-related scanpathplot argument names

### DIFF
--- a/src/pymovements/plotting/scanpathplot.py
+++ b/src/pymovements/plotting/scanpathplot.py
@@ -63,8 +63,8 @@ def scanpathplot(
         add_arrows: bool = True,
         arrow_color: str = 'black',
         arrow_rad: float = 0.25,
-        arrowstyle: str = 'simple',
-        mutation_scale: float = 40.,
+        arrow_style: str = 'simple',
+        arrow_scale: float = 40.,
         path_to_image_stimulus: str | None = None,
         stimulus_origin: str = 'upper',
         events: Events | EventDataFrame | None = None,
@@ -123,9 +123,9 @@ def scanpathplot(
         Color of arrows. (default: 'black')
     arrow_rad: float
         Controlling the curvature of the arrows. (default: 0.25)
-    arrowstyle: str
+    arrow_style: str
         The styling of arrow head, tail and shaft. (default: 'simple')
-    mutation_scale: float
+    arrow_scale: float
         Value with which attributes of arrowstyle will be scaled. (default: 40.)
     path_to_image_stimulus: str | None
         Path of the stimulus to be shown. (default: None)
@@ -231,8 +231,8 @@ def scanpathplot(
             ax,
             color=arrow_color,
             rad=arrow_rad,
-            arrowstyle=arrowstyle,
-            mutation_scale=mutation_scale,
+            arrowstyle=arrow_style,
+            mutation_scale=arrow_scale,
         )
 
     if gaze is not None and gaze.experiment is not None:

--- a/tests/unit/plotting/scanpathplot_test.py
+++ b/tests/unit/plotting/scanpathplot_test.py
@@ -234,7 +234,7 @@ def gaze_fixture(request, make_gaze):
                 'add_arrows': True,
                 'arrow_color': 'blue',
                 'arrow_rad': 0.0,
-                'arrowstyle': '->',
+                'arrow_style': '->',
             },
             id='param_arrows',
         ),


### PR DESCRIPTION
## Description

Changed param names. as requested in PR [https://github.com/pymovements/pymovements/pull/1457](url)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
