### PR TITLE
ci: ignore fixture tests in benchmarks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps =
 commands =
     pytest \
     --ignore=src \
+    --ignore=tests/fixtures \
     --ignore=tests/functional \
     --ignore=tests/integration \
     --ignore=tests/unit \


### PR DESCRIPTION
## Description

Fixture tests should be ignored when running `tox -e benchmark`