### PR TITLE
ci: welcome first-time contributors in their PR

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -20,4 +20,3 @@ jobs:
             Please make sure to read our [contributing guide](https://pymovements.readthedocs.io/en/latest/contributing/index.html).
 
             Feel encouraged to add yourself to the list of authors in our [`CITATION.cff`](https://github.com/pymovements/pymovements/blob/main/CITATION.cff).
-


### PR DESCRIPTION
## Description

This workflow posts a short comment on PRs that were created by a first-time contributor.

It links to our contributing guide and encourages to add theirselves to the authors in the CITATION.cff.