### PR TITLE
ci: add slackbot to multipleye and dili workspaces

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
         uses: amendx/slackbot-release@1.0.1
         with:
           slack_webhook_url: ${{ secrets.SLACK_MULTIPLEYE_WEBHOOK_URL }}
-      - name: Notify on UZH-DiLi workspace
+      - name: Notify on DiLi workspace
         uses: amendx/slackbot-release@1.0.1
         with:
           slack_webhook_url: ${{ secrets.SLACK_DILI_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

Following #1428 this adds the slackbot to other slack workspaces with a pymovements events channel.

## Implemented changes

- [x] add slackbot to MultiplEYE workspace
- [x] add slackbot to UZH dili workspace

