### PR TITLE
ci: remove unmaintained databooks in favor of nbstripout settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     rev: 0.9.1
     hooks:
       - id: nbstripout
-        args: [--keep-id, --keep-metadata-keys=cell.metadata.tags]
+        args: [--keep-id, --keep-metadata-keys=cell.metadata.tags, --extra-keys=metadata.kernelspec metadata.language_info]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:


### PR DESCRIPTION
## Description

Replace `databooks` with `nbstripout` settings for notebook metadata cleaning in pre-commit hooks.

`databooks` has not been updated since October 2023 and has Python 3.14 compatibility issues due to the removal of `Num` from the `ast` module, see https://github.com/pymovements/pymovements/pull/1525#issuecomment-4081874552. This change removes `databooks` and adds the behaviour achieved with the existing `nbstripout` argument, which is actively maintained and provides equivalent functionality.

`databooks` uses a whitelist approach stripping everything except specified fields, while `nbstripout` uses a blacklist approach keeping everything except specified fields. For the use case of keeping `tags` metadata and `id` fields, the behavior is equivalent.

## Implemented changes

- Remove `databooks` pre-commit hook `databooks-meta`.
- use equivalent arguments: `--keep-id`, `--keep-metadata-keys=cell.metadata.tags`, and `--extra-keys=metadata.kernelspec metadata.language_info` in `nbstripout` hook.
- Remove `python: python3.11` from `default_language_version`

## How Has This Been Tested?

- [x] Added kernelspec metadata manually to notebook, ran a notebook, then using the pre-commit hooks these informations were removed.

Due to the opt-in as described before, we might want to add more `extra-keys`, see 

## Context

Resolves #

#### related issues:
- #1525
- #1448 

#### required by:
- #

#### requires:
- [ ] #

#### conflicts with:
- #

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
