### PR TITLE
docs: display experiment via htmlrepr in user guide

### DIFF
--- a/docs/source/user-guide/experiment.ipynb
+++ b/docs/source/user-guide/experiment.ipynb
@@ -55,7 +55,7 @@
     "    origin=\"upper left\",\n",
     ")\n",
     "\n",
-    "display(screen)"
+    "screen"
    ]
   },
   {
@@ -127,7 +127,7 @@
     "    mount=\"Arm Mount / Monocular / Remote\",\n",
     ")\n",
     "\n",
-    "display(eyetracker)"
+    "eyetracker"
    ]
   },
   {
@@ -161,7 +161,7 @@
    "source": [
     "experiment = pm.Experiment(screen=screen, eyetracker=eyetracker)\n",
     "\n",
-    "display(experiment)"
+    "experiment"
    ]
   },
   {
@@ -189,7 +189,7 @@
     "    sampling_rate=1000.0,\n",
     ")\n",
     "\n",
-    "display(experiment_flat)"
+    "experiment_flat"
    ]
   },
   {
@@ -240,7 +240,7 @@
     "    }\n",
     "})\n",
     "\n",
-    "display(experiment_from_dict)"
+    "experiment_from_dict"
    ]
   },
   {


### PR DESCRIPTION
## Description

Follows comment from @cbueth https://github.com/pymovements/pymovements/pull/1530#issuecomment-4108970521

## Implemented changes

- [x] directly display screen, eyetracker experiment via htmlrepr instead of print

## How Has This Been Tested?

- [x] visually: https://pymovements--1536.org.readthedocs.build/en/1536/user-guide/experiment.html

## Context

comment from @cbueth https://github.com/pymovements/pymovements/pull/1530#issuecomment-4108970521


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
