### PR TITLE
depr: deprecate Screen.pix2deg()

### DIFF
--- a/src/pymovements/gaze/screen.py
+++ b/src/pymovements/gaze/screen.py
@@ -27,6 +27,7 @@ from numbers import Number
 from typing import Any
 
 import numpy as np
+from deprecated.sphinx import deprecated
 
 from pymovements._utils import _checks
 from pymovements._utils._html import repr_html
@@ -356,11 +357,20 @@ class Screen:
             ),
         )
 
+    @deprecated(
+        reason='Please use pymovements.transforms.pix2deg() instead. '
+               'This method will be removed in v0.32.0.',
+        version='v0.27.1',
+    )
     def pix2deg(
             self,
             arr: float | list[float] | list[list[float]] | np.ndarray,
     ) -> np.ndarray:
         """Convert pixel screen coordinates to degrees of visual angle.
+
+        .. deprecated:: v0.27.1
+           Please use :py:func:`~pymovements.transforms.pix2deg` instead.
+           This method will be removed in v0.32.0.
 
         Parameters
         ----------
@@ -388,7 +398,7 @@ class Screen:
         ...     distance_cm=68.0,
         ...     origin='upper left',
         ... )
-        >>> screen.pix2deg(arr=arr)
+        >>> screen.pix2deg(arr=arr)# doctest: +SKIP
         array([[-12.70732231, 8.65963972]])
 
         >>> screen = Screen(
@@ -399,7 +409,7 @@ class Screen:
         ...     distance_cm=68.0,
         ...     origin='center',
         ... )
-        >>> screen.pix2deg(arr=arr)
+        >>> screen.pix2deg(arr=arr)# doctest: +SKIP
         array([[ 3.07379946, 20.43909054]])
         """
         self._check_numerical_attribute('width_px')

--- a/tests/unit/gaze/screen_test.py
+++ b/tests/unit/gaze/screen_test.py
@@ -446,17 +446,33 @@ def test_dva_properties_with_distance_cm(property_name):
     getattr(screen, property_name)
 
 
+@pytest.mark.filterwarnings('ignore:.*pix2deg.*:DeprecationWarning')
 def test_screen_pix2deg_with_no_distance_cm():
     screen = pm.Screen(1920, 1080, 30, 20, None, 'upper left')
     with pytest.raises(TypeError):
         screen.pix2deg([[0, 0]])
 
 
+@pytest.mark.filterwarnings('ignore:.*pix2deg.*:DeprecationWarning')
 def test_screen_pix2deg_with_distance_cm():
     screen = pm.Screen(1920, 1080, 30, 20, 60, 'upper left')
     screen.pix2deg([[0, 0]])
 
 
+def test_screen_pix2deg_is_deprecated_or_removed(assert_deprecation_is_removed):
+    screen = pm.Screen(1920, 1080, 30, 20, 60, 'upper left')
+
+    with pytest.raises(DeprecationWarning) as info:
+        screen.pix2deg([[0, 0]])
+
+    assert_deprecation_is_removed(
+        function_name='pix2deg',
+        warning_message=info.value.args[0],
+        scheduled_version='0.32.0',
+    )
+
+
+@pytest.mark.filterwarnings('ignore:.*pix2deg.*:DeprecationWarning')
 @pytest.mark.parametrize(
     ('missing_attribute', 'exception', 'exception_msg'),
     [


### PR DESCRIPTION
## :warning: Deprecation

The method `Screen.pix2deg()` is deprecated in v0.27.1. Please use `transforms.pix2deg()` instead. This method will be removed in *pymovements v0.32.0*.

## Implemented changes

- [x] deprecate `Screen.pix2deg()` method

## How Has This Been Tested?

- [x] tested that method emits deprecation warning
- [x] tested that method is removed as scheduled
