### PR TITLE
chore: pass `calibrations` and `validations` to `Gaze` init in `from_asc`

### DIFF
--- a/src/pymovements/gaze/io.py
+++ b/src/pymovements/gaze/io.py
@@ -582,6 +582,10 @@ def from_asc(
             pl.concat_list([pl.col('pupil_left'), pl.col('pupil_right')]).alias('pupil'),
         ).drop(['pupil_left', 'pupil_right'])
 
+    # Build cal/val frames and consume them from metadata dict
+    calibrations = metadata_to_cal_frame(parsed_metadata)
+    validations = metadata_to_val_frame(parsed_metadata)
+
     gaze = Gaze(
         samples=samples,
         experiment=experiment,
@@ -592,10 +596,9 @@ def from_asc(
         time_unit='ms',
         pixel_columns=detected_pixel_columns,
         metadata=metadata,
+        calibrations=calibrations,
+        validations=validations,
     )
-    # Build cal/val frames and consume them from metadata dict
-    gaze.calibrations = metadata_to_cal_frame(parsed_metadata)
-    gaze.validations = metadata_to_val_frame(parsed_metadata)
     # Keep remaining metadata privately on Gaze
     gaze._metadata = dict(parsed_metadata)  # pylint: disable=protected-access
     return gaze


### PR DESCRIPTION
## Description

As #1546 has added the `calibrations` and `validations` field to `Gaze.__init__()`, the post-init attribute assignments in `from_asc()` are not needed anymore as the variables can be now directly passed to the initializer.

## Implemented changes

- [x] pass calibrations and validations to Gaze init in from_asc

## How Has This Been Tested?

Pure refactor. No changes in tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
