### PR TITLE
fix: explicitly set `empty_as_null` for `list.explode`

### DIFF
--- a/src/pymovements/transforms/savitzky_golay.py
+++ b/src/pymovements/transforms/savitzky_golay.py
@@ -148,7 +148,7 @@ def savitzky_golay(
             pl.col(input_column)
             .list.get(component)
             .map_batches(func, return_dtype=pl.Float64)
-            .list.explode()
+            .list.explode(empty_as_null=True)
             for component in range(n_components)
         ],
     ).alias(output_column)

--- a/src/pymovements/transforms/smooth.py
+++ b/src/pymovements/transforms/smooth.py
@@ -150,7 +150,7 @@ def smooth(
                     pl.col(column)
                     .list.get(component)
                     .map_batches(pad_func, return_dtype=pl.Float64)
-                    .list.explode()
+                    .list.explode(empty_as_null=True)
                     .rolling_mean(window_size=window_length, center=True)
                     .shift(n=pad_kwargs['pad_width'])
                     .slice(pad_kwargs['pad_width'] * 2)
@@ -163,7 +163,7 @@ def smooth(
                 pl.col(column)
                 .list.get(component)
                 .map_batches(pad_func, return_dtype=pl.Float64)
-                .list.explode()
+                .list.explode(empty_as_null=True)
                 .ewm_mean(
                     span=window_length,
                     adjust=False,


### PR DESCRIPTION
"DeprecationWarning: In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. To keep the current behavior, explicitly set `empty_as_null=True`."

## Description

Fixes all 59 test failures in tests/unit/transforms/ caused by a Polars deprecation warning being raised as an error. The warning "In Polars 2.0, the default behavior for empty_as_null will change to False" is triggered by `.list.explode()` calls and pytest's filterwarnings = ["error"] config converts it into a test failure.

## Implemented changes
- [x] Add `empty_as_null=True` to `.list.explode()` call in `savitzky_golay.py`
- [x] Add `empty_as_null=True` to `.list.explode()` call in `smooth.py` for moving average path AND exponential moving average path

## How Has This Been Tested?
- [x] Ran pytest tests/unit/transforms/. 433 passed, 0 failed

## Type of change
- Bug fix

## Context

Resolves #

#### related issues:
- #

#### required by:
- #

#### requires:
- [ ] #

#### conflicts with:
- #

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  Nothing to document.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  Using existent tests
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
