### PR TITLE
fix: add optional prefix to EyeLink calibration message regex

### DIFF
--- a/src/pymovements/gaze/_utils/_parsing_eyelink.py
+++ b/src/pymovements/gaze/_utils/_parsing_eyelink.py
@@ -112,6 +112,7 @@ BLINK_STOP_REGEX = (
 CALIBRATION_TIMESTAMP_REGEX = r'MSG\s+(?P<timestamp>\d+[.]?\d*)\s+!CAL\s*\n'
 
 CALIBRATION_REGEX = (
+    r'(?:MSG\s+\d+[.]?\d*\s+)?'
     r'>+\s+CALIBRATION\s+\(HV(?P<num_points>\d\d?),'
     r'(?P<type>.*)\).*'
     r'(?P<tracked_eye>RIGHT|LEFT):\s+<{9}'

--- a/tests/unit/gaze/_utils/_parsing_eyelink_test.py
+++ b/tests/unit/gaze/_utils/_parsing_eyelink_test.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """Tests pymovements asc to csv processing - eyelink."""
+# pylint: disable=too-many-lines
 import datetime
 import importlib
 import re

--- a/tests/unit/gaze/_utils/_parsing_eyelink_test.py
+++ b/tests/unit/gaze/_utils/_parsing_eyelink_test.py
@@ -594,6 +594,18 @@ def test_metadata_warnings(make_text_file, metadata, expected_msg):
             [{'timestamp': '7045618'}],
             id='cal_timestamp_no_cal_no_val',
         ),
+        pytest.param(
+            'MSG	7045618 !CAL\n'
+            'MSG	7045618 >>>>>>> CALIBRATION (HV9,P-CR) FOR LEFT: <<<<<<<<<\n',
+            [],
+            [{
+                'num_points': '9',
+                'timestamp': '7045618',
+                'tracked_eye': 'LEFT',
+                'type': 'P-CR',
+            }],
+            id='cal_with_msg',
+        ),
     ],
 )
 @pytest.mark.filterwarnings('ignore:No metadata found.')


### PR DESCRIPTION
## Description

Some ASC files prefix calibration lines with `MSG`, see #1595.

## Implemented changes

- [x] Add optional `MSG` prefix to regex

## How Has This Been Tested?

- [x] Add unit test for calibration lines with `MSG`
- [x] Tested with a real ASC file

## Type of change

- Bug fix

## Context

Resolves #1595

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
