### PR TITLE
fix: Add `nulls_equal=True` to table joins

### DIFF
--- a/src/pymovements/events/events.py
+++ b/src/pymovements/events/events.py
@@ -241,7 +241,7 @@ class Events:
         join_on: str | list[str]
             Columns to join event properties on.
         """
-        self.frame = self.frame.join(event_properties, on=join_on, how='left')
+        self.frame = self.frame.join(event_properties, on=join_on, how='left', nulls_equal=True)
 
     def drop(
             self,

--- a/src/pymovements/measure/reading/measures.py
+++ b/src/pymovements/measure/reading/measures.py
@@ -307,7 +307,7 @@ def saccade_length_out(fixations: pl.DataFrame) -> pl.DataFrame:
     )
 
     last_fixations = (
-        fixations.join(first_run, on=['trial', 'page', 'word_idx'])
+        fixations.join(first_run, on=['trial', 'page', 'word_idx'], nulls_equal=True)
         .filter(pl.col('run_id') == pl.col('first_run'))
         .group_by(['trial', 'page', 'word_idx'])
         .agg(pl.all().sort_by('onset').last())
@@ -445,19 +445,19 @@ def build_word_level_table(
     rpd = regression_path_duration(fixations)
 
     return (
-        words.join(tfc, on=['trial', 'page', 'word_idx'], how='left')
-        .join(fd, on=['trial', 'page', 'word_idx'], how='left')
-        .join(ffd, on=['trial', 'page', 'word_idx'], how='left')
-        .join(fprt, on=['trial', 'page', 'word_idx'], how='left')
-        .join(frt, on=['trial', 'page', 'word_idx'], how='left')
-        .join(rrt, on=['trial', 'page', 'word_idx'], how='left')
-        .join(fpfc, on=['trial', 'page', 'word_idx'], how='left')
-        .join(trc_in, on=['trial', 'page', 'word_idx'], how='left')
-        .join(trc_out, on=['trial', 'page', 'word_idx'], how='left')
-        .join(lp, on=['trial', 'page', 'word_idx'], how='left')
-        .join(sl_in, on=['trial', 'page', 'word_idx'], how='left')
-        .join(sl_out, on=['trial', 'page', 'word_idx'], how='left')
-        .join(rpd, on=['trial', 'page', 'word_idx'], how='left')
+        words.join(tfc, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(fd, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(ffd, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(fprt, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(frt, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(rrt, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(fpfc, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(trc_in, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(trc_out, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(lp, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(sl_in, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(sl_out, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
+        .join(rpd, on=['trial', 'page', 'word_idx'], how='left', nulls_equal=True)
         .with_columns(
             [
                 pl.col('TFC').fill_null(0),

--- a/src/pymovements/measure/reading/words.py
+++ b/src/pymovements/measure/reading/words.py
@@ -144,6 +144,7 @@ def mark_skipped_tokens(
         fixated_tokens,
         on=['trial', 'page', 'word_idx'],
         how='left',
+        nulls_equal=True,
     )
 
     return out.with_columns(

--- a/src/pymovements/transforms/segmentation.py
+++ b/src/pymovements/transforms/segmentation.py
@@ -413,6 +413,7 @@ def events2timeratio(
             sample_time_ranges,
             on=trial_columns,
             how='full',
+            nulls_equal=True,
         ).with_columns(
             (pl.col('duration') / pl.col('time_range')).alias(f'event_ratio_{name}'),
         )

--- a/tests/unit/gaze/gaze_test.py
+++ b/tests/unit/gaze/gaze_test.py
@@ -1690,6 +1690,33 @@ def test_gaze_compute_event_properties_overwrites_column(existing_amplitude, exp
     assert_frame_equal(gaze.events.frame, expected_events, check_column_order=False)
 
 
+def test_gaze_compute_event_properties_null_trial():
+    gaze = Gaze(
+        pl.DataFrame(
+            {
+                'time': [0, 1, 2, 3],
+                'x': [0, 1, 2, 3],
+                'y': [0, 1, 2, 3],
+                'trial_id': [1, 1, None, None],
+            },
+        ),
+        position_columns=['x', 'y'],
+        trial_columns=['trial_id'],
+        events=Events(
+            pl.DataFrame(
+                {
+                    'name': ['fixation', 'fixation'],
+                    'onset': [0, 1],
+                    'offset': [2, 3],
+                    'trial_id': [1, None],
+                },
+            ),
+        ),
+    )
+    gaze.compute_event_properties('location')
+    assert gaze.events.frame['location'].to_list() == [[0.5, 0.5], [2.5, 2.5]]
+
+
 @pytest.mark.parametrize(
     ('gaze', 'attribute'),
     [


### PR DESCRIPTION
## Description

See #1613.

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] Add `nulls_equal=True` to all polars `join` calls I could find

## How Has This Been Tested?

Didn't add a test, but checked that it works with some actual gaze data. Let me know if this requires a unit test.

## Type of change

- Bug fix

## Context

Resolves #1613

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
