### PR TITLE
docs: remove dead DAAD SVG build-time preparation code

### DIFF
--- a/docs/source/about-us/acknowledgments.rst
+++ b/docs/source/about-us/acknowledgments.rst
@@ -12,7 +12,7 @@ The pymovements project was partially funded by:
       :link: https://www.snf.ch
 
       .. image:: https://snf.styleguides.ch/userfiles/images/bilder/SNF_logo_Spezialversionen03.png
-         :height: 180
+        :width: 90%
 
       +++
       the Swiss National Science Foundation (SNSF) under grants IZCOZ0_220330 (EyeNLG) and 212276 (MeRID)
@@ -22,7 +22,7 @@ The pymovements project was partially funded by:
       :link: https://www.bmftr.bund.de
 
       .. image:: https://www.bmftr.bund.de/SiteGlobals/Frontend/Images/images/logo-en.svg?__blob=normal&v=4
-         :height: 150
+         :height: 120
 
       +++
       the German Federal Ministry of Education and Research (BMBF) under grant 01IS20043
@@ -31,8 +31,8 @@ The pymovements project was partially funded by:
       :text-align: center
       :link: https://www.daad.de
 
-      .. image:: /_static/daad-logo.svg
-         :height: 160
+      .. image:: https://static.daad.de/media/daad_de/der-daad/kommunikation-publikationen/daad_logo_suppl_de+en_h_basic_rgb.png
+        :width: 100%
 
       +++
       the DAAD programme Konrad Zuse Schools of Excellence in Artificial Intelligence (ELIZA)
@@ -42,7 +42,7 @@ The pymovements project was partially funded by:
       :link: https://www.cncs-nrc.ro
 
       .. image:: https://fundit.fr/sites/default/files/styles/max_650x650/public/actors/2318-autorite-nationale-pour-recherche-scientifique-roumanie-ancs.png
-         :height: 160
+        :width: 60%
 
       +++
       the Romanian National Research Council (CNCS) through the Executive Agency for Higher Education, Research, Development and Innovation Funding (UEFISCDI) under grant PN-IV-P2-2.1-TE-2023-2007 (InstRead)
@@ -57,7 +57,7 @@ and was supported by work from
       :link: https://www.cost.eu
 
       .. image:: https://www.cost.eu/uploads/2022/03/COST_LOGO_rgb_highresolution-1200x563.jpg
-         :height: 175
+        :width: 90%
 
       +++
       European Cooperation in Science and Technology
@@ -67,7 +67,7 @@ and was supported by work from
       :link: https://multipleye.eu
 
       .. image:: https://multipleye.eu/wp-content/uploads/2022/12/Logo-02-e1671544092743-768x451.png
-         :height: 165
+        :width: 70%
 
       +++
       COST Action MultiplEYE, CA21131

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,6 @@ import importlib.resources
 import inspect
 import os
 import sys
-import urllib.request
 from subprocess import CalledProcessError
 from subprocess import run
 
@@ -85,31 +84,6 @@ def config_inited_handler(app, config):
     os.makedirs(os.path.join(app.srcdir, app.config.generated_path), exist_ok=True)
 
 
-def builder_inited_handler(app):
-    """So we do not need to have the logo in the repo.
-
-    Get it at build time and add a `viewBox`, needed to have the right aspect ratio.
-    """
-    url = 'https://www.daad.de/_nuxt/logo-light.1I6xeyd5.svg'
-    static_dir = os.path.join(app.srcdir, '_static')
-    os.makedirs(static_dir, exist_ok=True)
-    daad_path = os.path.join(static_dir, 'daad-logo.svg')
-
-    try:
-        with urllib.request.urlopen(url, timeout=30) as response:
-            svg_content = response.read().decode('utf-8')
-    except Exception as e:
-        raise RuntimeError(
-            f"Failed to download DAAD logo from {url}: {e}",
-        )
-
-    if 'viewBox' not in svg_content:
-        svg_content = svg_content.replace('<svg', '<svg viewBox="0 0 380 102"', 1)
-
-    with open(daad_path, 'w') as f:
-        f.write(svg_content)
-
-
 def doctree_resolved_handler(app, doctree, docname):
     """Open all external links in a new tab."""
     from docutils import nodes
@@ -125,7 +99,6 @@ def setup(app):
     app.add_config_value('REVISION', 'master', 'env')
     app.add_config_value('generated_path', '_generated', 'env')
     app.connect('config-inited', config_inited_handler)
-    app.connect('builder-inited', builder_inited_handler)
     app.connect('doctree-resolved', doctree_resolved_handler)
 
 


### PR DESCRIPTION
## Description

Due to the instability of the `https://www.daad.de/_nuxt/logo-light.1I6xeyd5.svg` file in CI building, this PR removes the `builder_inited_handler` function and its import `urllib.request` from `conf.py`, which downloaded a DAAD SVG logo at build time and injected a `viewBox` attribute. This code is no longer needed since the acknowledgments page now references the DAAD PNG logo directly from its remote URL. The `doctree_resolved_handler` is preserved as it serves a separate purpose.

## Implemented changes

- [x] Resize all logos
- [x] Change daad logo to png
- [x] Remove svg build code

## How Has This Been Tested?

- [x] Local build `sphinx-build --color -W --keep-going -d docs/doctree -b html docs/source docs/build -D nb_execution_mode=off -D "suppress_warnings=myst-nb.lexer,toc.not_included,myst.header"` (build without notebooks). And manual inspection

## Type of change

## Context

Resolves #

#### related issues:
- #1588 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
