### PR TITLE
chore!: remove deprecated DatasetDefinitions.mirror ahead of schedule

### DIFF
--- a/src/pymovements/dataset/dataset_definition.py
+++ b/src/pymovements/dataset/dataset_definition.py
@@ -61,17 +61,10 @@ class DatasetDefinition:
     description: str | None
         A fulltext description of the dataset.
         (default: None)
-    mirrors: dict[str, Sequence[str]]
-        A list of mirrors of the dataset. Each entry must be of type `str` and end with a '/'.
-        (default: {})
-
-        .. deprecated:: v0.24.0
-           Please use :py:attr:`~pymovements.ResourceDefinition.mirrors` instead.
-           This field will be removed in v0.29.0.
     resources: ResourceDefinitions
         A list of dataset resources. Each list entry must be a dictionary with the following keys:
 
-        - `resource`: The url suffix of the resource. This will be concatenated with the mirror.
+        - `resource`: The url suffix of the resource.
         - `filename`: The filename under which the file is saved as.
         - `md5`: The MD5 checksum of the respective file.
 
@@ -179,17 +172,10 @@ class DatasetDefinition:
 
         .. deprecated:: v0.23.0
            This field will be removed in v0.28.0.
-    mirrors: dict[str, Sequence[str]] | None
-        A list of mirrors of the dataset. Each entry must be of type `str` and end with a '/'.
-        (default: None)
-
-        .. deprecated:: v0.24.0
-           Please use :py:attr:`~pymovements.ResourceDefinition.mirrors`. instead.
-           This field will be removed in v0.29.0.
     resources: ResourceDefinitions | ResourcesLike | None
         A list of dataset resources. Each list entry must be a dictionary with the following keys:
 
-        - `resource`: The url suffix of the resource. This will be concatenated with the mirror.
+        - `source`: The url suffix of the resource.
         - `filename`: The filename under which the file is saved as.
         - `md5`: The MD5 checksum of the respective file.
 
@@ -296,8 +282,6 @@ class DatasetDefinition:
 
     description: str | None = None
 
-    mirrors: dict[str, Sequence[str]] = field(default_factory=dict)
-
     resources: ResourceDefinitions = field(default_factory=ResourceDefinitions)
 
     experiment: Experiment | None = field(default_factory=Experiment)
@@ -322,7 +306,6 @@ class DatasetDefinition:
             long_name: str | None = None,
             description: str | None = None,
             has_files: dict[str, bool] | None = None,
-            mirrors: dict[str, Sequence[str]] | None = None,
             resources: ResourceDefinitions | ResourcesLike | None = None,
             experiment: Experiment | None = None,
             filename_format: dict[str, str] | None = None,
@@ -346,18 +329,6 @@ class DatasetDefinition:
 
         self.resources = self._initialize_resources(resources=resources)
         self._has_resources = _HasResourcesIndexer(resources=self.resources)
-
-        if mirrors is None:
-            self.mirrors = {}
-        else:
-            warn(
-                DeprecationWarning(
-                    'DatasetDefinition.mirrors is deprecated since version v0.24.0. '
-                    'Please specify ResourceDefinition.mirrors instead. '
-                    'This field will be removed in v0.29.0.',
-                ),
-            )
-            self.mirrors = mirrors
 
         if trial_columns is not None:
             warn(

--- a/src/pymovements/dataset/dataset_download.py
+++ b/src/pymovements/dataset/dataset_download.py
@@ -21,16 +21,10 @@
 from __future__ import annotations
 
 import shutil
-from collections.abc import Sequence
-from pathlib import Path
-from urllib.error import URLError
-from warnings import warn
 
 from pymovements.dataset._utils._archives import extract_archive
 from pymovements.dataset.dataset_definition import DatasetDefinition
 from pymovements.dataset.dataset_paths import DatasetPaths
-from pymovements.dataset.resources import ResourceDefinition
-from pymovements.dataset.websource import _download_file
 from pymovements.exceptions import UnknownFileType
 
 
@@ -95,26 +89,11 @@ def download_dataset(
         )
 
     for resource in downloadable_resources:
-        if not definition.mirrors:
-            mirrors = None
-        else:
-            # legacy mirrors defined mirror for each content type.
-            mirrors = definition.mirrors.get(resource.content, None)
-
-        if not mirrors:
-            resource.source.download(
-                target_dirpath=paths.downloads,
-                verbose=verbose,
-                verify_checksum=verify_checksum,
-            )
-        else:
-            _download_resource_with_legacy_mirrors(
-                mirrors=mirrors,
-                resource=resource,
-                target_dirpath=paths.downloads,
-                verify_checksum=verify_checksum,
-                verbose=verbose,
-            )
+        resource.source.download(
+            target_dirpath=paths.downloads,
+            verbose=verbose,
+            verify_checksum=verify_checksum,
+        )
 
     if extract:
         extract_dataset(
@@ -184,44 +163,3 @@ def extract_dataset(
                     )
                 except UnknownFileType:  # just copy file to target if not an archive.
                     shutil.copy(source_path, destination_dirpath / resource.source.filename)
-
-
-def _download_resource_with_legacy_mirrors(
-        mirrors: Sequence[str],
-        resource: ResourceDefinition,
-        target_dirpath: Path,
-        verify_checksum: bool,
-        verbose: bool,
-) -> None:
-    """Download resource with mirrors."""
-    if resource.source is None or resource.source.url is None:
-        raise AttributeError('WebSource.url must not be None')
-    if resource.source.filename is None:
-        raise AttributeError('WebSource.filename must not be None')
-
-    for mirror_idx, mirror in enumerate(mirrors, start=1):
-        mirror_url = f'{mirror}{resource.source.url}'
-        try:
-            _download_file(
-                url=mirror_url,
-                dirpath=target_dirpath,
-                filename=resource.source.filename,
-                md5=resource.source.md5,
-                verify_checksum=verify_checksum,
-                verbose=verbose,
-            )
-            return  # Download successful
-        # pylint: disable=overlapping-except
-        except (URLError, OSError, RuntimeError) as error:
-            # Error downloading the resource, try next mirror
-            if mirror_idx < len(mirrors):
-                warning = UserWarning(
-                    f'Downloading resource from mirror {mirror_url} failed.'
-                    f' Trying next mirror ({len(mirrors) - mirror_idx} remaining).',
-                )
-                warning.__cause__ = error
-                warn(warning)
-
-    raise RuntimeError(
-        f'Downloading resource {resource.source.url} failed for all mirrors.',
-    )

--- a/tests/unit/dataset/dataset_definition_test.py
+++ b/tests/unit/dataset/dataset_definition_test.py
@@ -330,7 +330,6 @@ def test_dataset_definition_resources_init_expected(init_kwargs, expected_resour
                 'description': None,
                 'distance_column': None,
                 'experiment': None,
-                'mirrors': {},
                 'pixel_columns': None,
                 'position_columns': None,
                 'resources': [],
@@ -382,7 +381,6 @@ def test_dataset_definition_resources_init_expected(init_kwargs, expected_resour
                         'width_px': 1280,
                     },
                 },
-                'mirrors': {},
                 'pixel_columns': None,
                 'position_columns': None,
                 'resources': [],
@@ -431,7 +429,6 @@ def test_dataset_definition_to_dict_expected(definition, expected_dict):
                         'width_px': None,
                     },
                 },
-                'mirrors': {},
                 'pixel_columns': None,
                 'position_columns': None,
                 'resources': [],
@@ -473,7 +470,6 @@ def test_dataset_definition_to_dict_expected(definition, expected_dict):
                         'width_px': None,
                     },
                 },
-                'mirrors': {},
                 'pixel_columns': None,
                 'position_columns': None,
                 'resources': [],
@@ -535,7 +531,6 @@ def test_dataset_definition_to_yaml_equal_dicts(definition, tmp_path):
     assert definition.to_dict() == yaml_dict
 
 
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 def test_write_yaml_already_existing_dataset_definition_w_tuple_screen(tmp_path):
     tmp_file = tmp_path / 'tmp.yaml'
     definition = DatasetLibrary.get('ToyDatasetEyeLink')
@@ -780,7 +775,6 @@ def test_dataset_definition_has_resources_not_equal():
                 'name': '.',
                 'long_name': None,
                 'description': None,
-                'mirrors': {},
                 'resources': [],
                 'experiment': None,
                 'column_map': None,
@@ -804,7 +798,6 @@ def test_dataset_definition_has_resources_not_equal():
                 'name': '.',
                 'long_name': None,
                 'description': None,
-                'mirrors': {},
                 'resources': [],
                 'experiment': None,
                 'column_map': None,
@@ -828,7 +821,6 @@ def test_dataset_definition_has_resources_not_equal():
                 'name': '.',
                 'long_name': None,
                 'description': None,
-                'mirrors': {},
                 'resources': [],
                 'experiment': {
                     'eyetracker': {
@@ -912,7 +904,6 @@ def test_dataset_definition_has_resources_not_equal():
                 'distance_column': None,
                 'experiment': None,
                 'long_name': None,
-                'mirrors': {},
                 'name': '.',
                 'pixel_columns': None,
                 'position_columns': None,
@@ -993,7 +984,6 @@ def test_dataset_definition_has_resources_not_equal():
                 'distance_column': None,
                 'experiment': None,
                 'long_name': None,
-                'mirrors': {},
                 'name': '.',
                 'pixel_columns': None,
                 'position_columns': None,
@@ -1039,11 +1029,6 @@ def test_dataset_to_dict_exclude_none(dataset_definition, exclude_none, expected
             {'has_files': {'gaze': True}},
             '0.28.0',
             id='has_files',
-        ),
-        pytest.param(
-            {'mirrors': {'gaze': ['https://mirror.com']}},
-            '0.29.0',
-            id='mirrors',
         ),
         pytest.param(
             {

--- a/tests/unit/dataset/dataset_download_test.py
+++ b/tests/unit/dataset/dataset_download_test.py
@@ -35,22 +35,17 @@ from pymovements import DatasetPaths
     name='dataset_definition',
     params=[
         'CustomGazeAndPrecomputedSingleMirror',
-        'CustomGazeAndPrecomputedLegacyMirror',
         'CustomGazeAndPrecomputedNoMirror',
         'CustomGazeOnlySingleMirror',
         'CustomGazeOnlyTwoMirrors',
-        'CustomGazeOnlyLegacyMirror',
         'CustomGazeOnlyNoMirror',
         'CustomGazeImageStimuli',
         'CustomGazeTextStimuli',
         'CustomPrecomputedOnlySingleMirror',
-        'CustomPrecomputedOnlyLegacyMirror',
         'CustomPrecomputedOnlyNoMirror',
         'CustomPrecomputedOnlyNoExtractSingleMirror',
-        'CustomPrecomputedOnlyNoExtractLegacyMirror',
         'CustomPrecomputedOnlyNoExtractNoMirror',
         'CustomPrecomputedRMOnlySingleMirror',
-        'CustomPrecomputedRMOnlyLegacyMirror',
         'CustomPrecomputedRMOnlyNoMirror',
         'CustomImageStimuli',
         'CustomTextStimuli',
@@ -75,39 +70,6 @@ def dataset_definition_fixture(request):  # pylint: disable=too-many-return-stat
                     'source': {
                         'url': 'https://example.com/test_pc.gz.tar',
                         'mirrors': ['https://another_example.com/test_pc.gz.tar'],
-                        'filename': 'test_pc.gz.tar',
-                        'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
-                    },
-                },
-            ],
-        )
-
-    if request.param == 'CustomGazeAndPrecomputedLegacyMirror':
-        return DatasetDefinition(
-            name='CustomPublicDataset',
-            mirrors={
-                'gaze': (
-                    'https://example.com/',
-                    'https://another_example.com/',
-                ),
-                'precomputed_events': (
-                    'https://example.com/',
-                    'https://another_example.com/',
-                ),
-            },
-            resources=[
-                {
-                    'content': 'gaze',
-                    'source': {
-                        'url': 'test.gz.tar',
-                        'filename': 'test.gz.tar',
-                        'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
-                    },
-                },
-                {
-                    'content': 'precomputed_events',
-                    'source': {
-                        'url': 'test_pc.gz.tar',
                         'filename': 'test_pc.gz.tar',
                         'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
                     },
@@ -166,27 +128,6 @@ def dataset_definition_fixture(request):  # pylint: disable=too-many-return-stat
                             'https://mirror1.example.com/test.gz.tar',
                             'https://mirror2.example.com/test.gz.tar',
                         ],
-                        'filename': 'test.gz.tar',
-                        'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
-                    },
-                },
-            ],
-        )
-
-    if request.param == 'CustomGazeOnlyLegacyMirror':
-        return DatasetDefinition(
-            name='CustomPublicDataset',
-            mirrors={
-                'gaze': (
-                    'https://example.com/',
-                    'https://another_example.com/',
-                ),
-            },
-            resources=[
-                {
-                    'content': 'gaze',
-                    'source': {
-                        'url': 'test.gz.tar',
                         'filename': 'test.gz.tar',
                         'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
                     },
@@ -271,27 +212,6 @@ def dataset_definition_fixture(request):  # pylint: disable=too-many-return-stat
             ],
         )
 
-    if request.param == 'CustomPrecomputedOnlyLegacyMirror':
-        return DatasetDefinition(
-            name='CustomPublicDataset',
-            mirrors={
-                'precomputed_events': (
-                    'https://example.com/',
-                    'https://another_example.com/',
-                ),
-            },
-            resources=[
-                {
-                    'content': 'precomputed_events',
-                    'source': {
-                        'url': 'test_pc.gz.tar',
-                        'filename': 'test_pc.gz.tar',
-                        'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
-                    },
-                },
-            ],
-        )
-
     if request.param == 'CustomPrecomputedOnlyNoMirror':
         return DatasetDefinition(
             name='CustomPublicDataset',
@@ -323,27 +243,6 @@ def dataset_definition_fixture(request):  # pylint: disable=too-many-return-stat
             ],
         )
 
-    if request.param == 'CustomPrecomputedOnlyNoExtractLegacyMirror':
-        return DatasetDefinition(
-            name='CustomPublicDataset',
-            mirrors={
-                'precomputed_events': (
-                    'https://example.com/',
-                    'https://another_example.com/',
-                ),
-            },
-            resources=[
-                {
-                    'content': 'precomputed_events',
-                    'source': {
-                        'url': 'test_pc.gz.tar',
-                        'filename': 'test_pc.gz.tar',
-                        'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
-                    },
-                },
-            ],
-        )
-
     if request.param == 'CustomPrecomputedOnlyNoExtractNoMirror':
         return DatasetDefinition(
             name='CustomPublicDataset',
@@ -368,27 +267,6 @@ def dataset_definition_fixture(request):  # pylint: disable=too-many-return-stat
                     'source': {
                         'url': 'https://example.com/test_rm.gz.tar',
                         'mirrors': ['https://another_example.com/test_rm.gz.tar'],
-                        'filename': 'test_rm.gz.tar',
-                        'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
-                    },
-                },
-            ],
-        )
-
-    if request.param == 'CustomPrecomputedRMOnlyLegacyMirror':
-        return DatasetDefinition(
-            name='CustomPublicDataset',
-            mirrors={
-                'precomputed_reading_measures': (
-                    'https://example.com/',
-                    'https://another_example.com/',
-                ),
-            },
-            resources=[
-                {
-                    'content': 'precomputed_reading_measures',
-                    'source': {
-                        'url': 'test_rm.gz.tar',
                         'filename': 'test_rm.gz.tar',
                         'md5': '52bbf03a7c50ee7152ccb9d357c2bb30',
                     },
@@ -444,7 +322,6 @@ def dataset_definition_fixture(request):  # pylint: disable=too-many-return-stat
     assert False, f'unknown dataset_definition fixture {request.param}'
 
 
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     ('init_path', 'expected_paths'),
     [
@@ -520,487 +397,10 @@ def test_dataset_download_no_sources_raises(tmp_path):
         dataset.download()
 
 
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomGazeOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_both_mirrors_fail_gaze_only(
-        mock_download_file,
-        tmp_path,
-        dataset_definition,
-):
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-
-    mock_download_file.side_effect = OSError
-
-    with pytest.raises(
-        RuntimeError,
-        match='Downloading resource test.gz.tar failed for all mirrors',
-    ):
-        dataset.download()
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_precomputed_events_both_mirrors_fail(
-        mock_download_file,
-        tmp_path,
-        dataset_definition,
-):
-    mock_download_file.side_effect = OSError()
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-
-    with pytest.raises(
-        RuntimeError,
-        match='Downloading resource test_pc.gz.tar failed for all mirrors',
-    ):
-        dataset.download()
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedRMOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_precomputed_reading_measures_both_mirrors_fail(
-        mock_download_file,
-        tmp_path,
-        dataset_definition,
-):
-    mock_download_file.side_effect = OSError()
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-
-    with pytest.raises(
-        RuntimeError,
-        match='Downloading resource test_rm.gz.tar failed for all mirrors',
-    ):
-        dataset.download()
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test_rm.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_rm.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test_rm.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_rm.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomGazeAndPrecomputedLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_precomputed_and_gaze_both_mirrors_fail(
-        mock_download_file,
-        tmp_path,
-        dataset_definition,
-):
-    mock_download_file.side_effect = OSError()
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-
-    with pytest.raises(
-        RuntimeError,
-        match='Downloading resource test.gz.tar failed for all mirrors',
-    ):
-        dataset.download()
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomGazeOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_first_mirror_gaze_fails(mock_download_file, tmp_path, dataset_definition):
-    mock_download_file.side_effect = [OSError(), None]
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-    dataset.download(extract=False)
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_first_mirror_precomputed_fails(
-        mock_download_file, tmp_path, dataset_definition,
-):
-    mock_download_file.side_effect = [OSError(), None]
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-    dataset.download(extract=False)
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedRMOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_first_mirror_precomputed_fails_rm(
-        mock_download_file, tmp_path, dataset_definition,
-):
-    mock_download_file.side_effect = [OSError(), None]
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-    dataset.download(extract=False)
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test_rm.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_rm.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test_rm.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_rm.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomGazeAndPrecomputedLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_first_mirror_fails(mock_download_file, tmp_path, dataset_definition):
-    mock_download_file.side_effect = [OSError(), None, OSError(), None]
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-    dataset.download(extract=False)
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-        mock.call(
-            url='https://another_example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    [
-        'CustomGazeOnlyLegacyMirror',
-        'CustomGazeAndPrecomputedLegacyMirror',
-    ],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_file_not_found(mock_download_file, tmp_path, dataset_definition):
-    mock_download_file.side_effect = RuntimeError()
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-
-    with pytest.raises(RuntimeError):
-        dataset.download()
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.filterwarnings('ignore:Downloading resource .* failed.*:UserWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_file_precomputed_not_found(
-        mock_download_file, tmp_path, dataset_definition,
-):
-    mock_download_file.side_effect = RuntimeError()
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-
-    with pytest.raises(RuntimeError):
-        dataset.download()
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomGazeOnlyLegacyMirror', 'CustomGazeAndPrecomputedLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_no_extract(mock_download_file, tmp_path, dataset_definition):
-    mock_download_file.return_value = 'path'
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-    dataset.download(extract=False)
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_precomputed_no_extract(mock_download_file, tmp_path, dataset_definition):
-    mock_download_file.return_value = 'path'
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-    dataset.download(extract=False)
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test_pc.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_pc.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedRMOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_precomputed_no_extract_rm(
-        mock_download_file, tmp_path, dataset_definition,
-):
-    mock_download_file.return_value = 'path'
-
-    paths = DatasetPaths(root=tmp_path, dataset='.')
-    dataset = Dataset(dataset_definition, path=paths)
-    dataset.download(extract=False)
-
-    mock_download_file.assert_has_calls([
-        mock.call(
-            url='https://example.com/test_rm.gz.tar',
-            dirpath=tmp_path / 'downloads',
-            filename='test_rm.gz.tar',
-            md5='52bbf03a7c50ee7152ccb9d357c2bb30',
-            verify_checksum=True,
-            verbose=True,
-        ),
-    ])
-
-
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
-        'CustomGazeOnlyLegacyMirror',
         'CustomGazeOnlySingleMirror',
         'CustomGazeOnlyTwoMirrors',
         'CustomGazeOnlyNoMirror',
@@ -1032,11 +432,9 @@ def test_dataset_extract_remove_finished_true_gaze(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
-        'CustomPrecomputedRMOnlyLegacyMirror',
         'CustomPrecomputedRMOnlySingleMirror',
         'CustomPrecomputedRMOnlyNoMirror',
     ],
@@ -1067,11 +465,9 @@ def test_dataset_extract_rm(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
-        'CustomGazeAndPrecomputedLegacyMirror',
         'CustomGazeAndPrecomputedSingleMirror',
         'CustomGazeAndPrecomputedNoMirror',
     ],
@@ -1111,11 +507,9 @@ def test_dataset_extract_remove_finished_true_both(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
-        'CustomPrecomputedOnlyLegacyMirror',
         'CustomPrecomputedOnlySingleMirror',
         'CustomPrecomputedOnlyNoMirror',
     ],
@@ -1146,7 +540,6 @@ def test_dataset_extract_remove_finished_true_precomputed(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
@@ -1182,12 +575,10 @@ def test_dataset_extract_remove_finished_true_stimuli(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
         'CustomGazeAndPrecomputedSingleMirror',
-        'CustomGazeAndPrecomputedLegacyMirror',
         'CustomGazeAndPrecomputedNoMirror',
     ],
     indirect=['dataset_definition'],
@@ -1226,11 +617,9 @@ def test_dataset_extract_remove_finished_false_both(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
-        'CustomGazeOnlyLegacyMirror',
         'CustomGazeOnlySingleMirror',
         'CustomGazeOnlyTwoMirrors',
         'CustomGazeOnlyNoMirror',
@@ -1262,11 +651,9 @@ def test_dataset_extract_remove_finished_false_gaze(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
-        'CustomPrecomputedOnlyLegacyMirror',
         'CustomPrecomputedOnlySingleMirror',
         'CustomPrecomputedOnlyNoMirror',
     ],
@@ -1297,7 +684,6 @@ def test_dataset_extract_remove_finished_false_precomputed(
 
 
 @mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     'dataset_definition',
     [
@@ -1330,63 +716,6 @@ def test_dataset_extract_remove_finished_false_stimuli(
             verbose=1,
         ),
     ])
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomGazeAndPrecomputedLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_default_extract_both(
-        mock_extract, mock_download, tmp_path, dataset_definition,
-):
-    mock_extract.return_value = None
-    mock_download.return_value = None
-
-    Dataset(dataset_definition, path=tmp_path).download()
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomGazeOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_default_extract_gaze(
-        mock_extract, mock_download, tmp_path, dataset_definition,
-):
-    mock_extract.return_value = None
-    mock_download.return_value = None
-
-    Dataset(dataset_definition, path=tmp_path).download()
-
-    mock_download.assert_called_once()
-    mock_extract.assert_called_once()
-
-
-@mock.patch('pymovements.dataset.dataset_download._download_file')
-@mock.patch('pymovements.dataset.dataset_download.extract_archive')
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
-@pytest.mark.parametrize(
-    'dataset_definition',
-    ['CustomPrecomputedOnlyLegacyMirror'],
-    indirect=['dataset_definition'],
-)
-def test_dataset_download_default_extract_precomputed(
-        mock_extract, mock_download, tmp_path, dataset_definition,
-):
-    mock_extract.return_value = None
-    mock_download.return_value = None
-
-    Dataset(dataset_definition, path=tmp_path).download()
-
-    mock_download.assert_called_once()
-    mock_extract.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -1487,14 +816,12 @@ def test_dataset_download_raises_exception(
         Dataset(dataset_definition, path=tmp_path).download()
 
 
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 @pytest.mark.parametrize(
     ('init_kwargs', 'expected_exception', 'expected_msg'),
     [
         pytest.param(
             {
                 'name': 'CustomPublicDataset',
-                'mirrors': {'gaze': ['https://example.com/']},
                 'resources': [
                     {
                         'content': 'gaze',
@@ -1513,7 +840,6 @@ def test_dataset_download_raises_exception(
         pytest.param(
             {
                 'name': 'CustomPublicDataset',
-                'mirrors': {'gaze': ['https://example.com/']},
                 'resources': [
                     {
                         'content': 'gaze',
@@ -1539,11 +865,9 @@ def test_dataset_download_legacy_mirror_raises_exception(
         Dataset(dataset_definition, path=tmp_path).download()
 
 
-@pytest.mark.filterwarnings('ignore:DatasetDefinition.mirrors is deprecated.*:DeprecationWarning')
 def test_public_dataset_registered_correct_attributes(tmp_path, dataset_definition):
     dataset = Dataset(dataset_definition, path=tmp_path)
 
-    assert dataset.definition.mirrors == dataset_definition.mirrors
     assert dataset.definition.resources == dataset_definition.resources
     assert dataset.definition.experiment == dataset_definition.experiment
 

--- a/tests/unit/dataset/dataset_download_test.py
+++ b/tests/unit/dataset/dataset_download_test.py
@@ -857,7 +857,7 @@ def test_dataset_download_raises_exception(
         ),
     ],
 )
-def test_dataset_download_legacy_mirror_raises_exception(
+def test_dataset_download_websource_missing_attributes_raises_exception(
         init_kwargs, expected_exception, expected_msg, tmp_path,
 ):
     dataset_definition = DatasetDefinition(**init_kwargs)


### PR DESCRIPTION
## :boom: Breaking change

The `DatasetDefinitions.mirror` attribute was removed ahead of schedule (orignally planned for v0.29.0) as it blocked further development. Please use `WebSource.mirrors` instead.

## Implemented changes

- [x] remove `mirrors` attribute from `DatasetDefinition`
- [x] remove legacy mirror behavior from `dataset_download.py`
- [x] remove all legacy tests within `dataset_download_test.py` and `dataset_definition_test.py`
