### PR TITLE
ci: allow unsafe pr checkout for dataset docs

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -97,6 +97,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Setup python
         uses: actions/setup-python@v5


### PR DESCRIPTION
# Description

This is just an intermediary PR to quick fix the current problems with running our CI on forks.

We get the following error otherwise for the `docs` job in `.github/workflows/dataset.yml`:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

The `allow-unsafe-pr-checkout` option should be set to `false` again as soon as possible to secure our tokens.
