### PR TITLE
ci: remove failing write_dataset_docpages

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -1,21 +1,20 @@
 name: datasets
 
 on:
-  pull_request_target:
-    branches: [main]
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  cancel-in-progress: false
 
 jobs:
   prepare-matrix:
     name: prepare dataset matrix
-    if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     outputs:
       all_datasets: ${{ steps.create-matrix.outputs.matrix }}
@@ -41,7 +40,6 @@ jobs:
     name: test ${{ matrix.dataset }}
     runs-on: ubuntu-latest
     needs: [prepare-matrix]
-    if: startsWith(github.event.ref, 'refs/tags/v')
     strategy:
       fail-fast: false
       matrix:
@@ -85,33 +83,3 @@ jobs:
 
       - name: Run dataset integration test
         run: tox --skip-pkg-install -e integration -- tests/integration/download_dataset_test.py::test_download_dataset[${{ matrix.dataset }}]
-
-  docs:
-    name: docs
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request_target' }}
-    steps:
-      - name: Checkout pymovements repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install pymovements
-        run: python -m pip install -e ${{ github.workspace }}
-
-      - name: Write RST files
-        run: python src/pymovements/_scripts/write_dataset_docpages.py
-
-      - name: Commit dataset documentation changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: 'docs'
-          message: 'update datasets documentation'
-          default_author: github_actions


### PR DESCRIPTION
# Description

Removes the failing `docs` job from `datasets.yml`.

## Context

GitHub now refuses to check out fork code in a `pull_request_target` workflow:

> Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

Opting in via `allow-unsafe-pr-checkout: true` would silence the error without fixing the vulnerability.

## Context

Follow-up: #1630