### PR TITLE
docs: fix Savitzki-Golay citation usage

### DIFF
--- a/src/pymovements/transforms/savitzky_golay.py
+++ b/src/pymovements/transforms/savitzky_golay.py
@@ -44,7 +44,7 @@ def savitzky_golay(
         derivative: int = 0,
         padding: str | float | int | None = 'nearest',
 ) -> pl.Expr:
-    """Apply a 1-D Savitzky-Golay filter to a column|_|:cite:p:`SavitzkyGolay1964`.
+    """Apply a 1-D Savitzky-Golay filter to a column :cite:p:`SavitzkyGolay1964`.
 
     Parameters
     ----------


### PR DESCRIPTION
Not sure what the `|_|` means, but it prevents the citation from being rendered properly.